### PR TITLE
fix: Cancel the fsckd check prompt at boot time

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+systemd (255.2-4deepin2) unstable; urgency=medium
+
+  * Cancel the fsckd check prompt at boot time.
+
+ -- liujianqiang <liujianqiang@uniontech.com>  Mon, 23 Sep 2024 18:01:23 +0800
+
 systemd (255.2-4deepin1) sid; urgency=medium
 
   * Adapt UOS mandatory access control.

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -15,3 +15,4 @@ test-flush-the-socket-once-the-triggered-unit-exits.patch
 test-install-correct-kpartx-udev-rules-on-Debian.patch
 
 adapt-umac-of-usec.patch
+uniontech001-cancel-the-fsckd-check-prompt-at-boot-time.patch

--- a/debian/patches/uniontech001-cancel-the-fsckd-check-prompt-at-boot-time.patch
+++ b/debian/patches/uniontech001-cancel-the-fsckd-check-prompt-at-boot-time.patch
@@ -1,0 +1,13 @@
+Index: systemd/src/fsckd/fsckd.c
+===================================================================
+--- systemd.orig/src/fsckd/fsckd.c	2024-05-31 10:23:24.539775004 +0800
++++ systemd/src/fsckd/fsckd.c	2024-05-31 10:46:32.078365864 +0800
+@@ -319,7 +319,7 @@
+                 l10n_cancel_message = _("Press Ctrl+C to cancel all filesystem checks in progress");
+                 plymouth_cancel_message = strjoina("fsckd-cancel-msg:", l10n_cancel_message);
+ 
+-                r = plymouth_send_message(m->plymouth_fd, plymouth_cancel_message, false);
++                r = plymouth_send_message(m->plymouth_fd, "", false);
+                 if (r < 0)
+                         log_warning_errno(r, "Can't send filesystem cancel message to plymouth: %m");
+ 


### PR DESCRIPTION
Description: Cancel the fsckd check prompt at boot time

Bug: https://pms.uniontech.com/bug-view-251979.html
Log: Cancel the fsckd check prompt at boot time