### PR TITLE
feat：usec support security.usec_proc attr, modify default usid context of systemd.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+systemd (255.2-4deepin4) unstable; urgency=medium
+
+  * change security.selinux2 to security.usec_proc attr.
+  * systemd default usid context is "root:object_r:deepin_usec_t:s0"
+
+ -- zhouzilong <zhouzilong@uniontech.com>  Sat, 30 Nov 2024 11:30:33 +0800
+
 systemd (255.2-4deepin3) unstable; urgency=medium
 
   * add usecfs magic.
@@ -14,7 +21,7 @@ systemd (255.2-4deepin1) sid; urgency=medium
 
   * Adapt UOS mandatory access control.
 
--- luxinyou <luxinyou@uniontech.com>  Wed, 04 Sep 2024 19:05:00 +0800
+ -- luxinyou <luxinyou@uniontech.com>  Wed, 04 Sep 2024 19:05:00 +0800
 
 systemd (255.2-4) sid; urgency=medium
 

--- a/debian/patches/change-security.selinux2-to-security.usec_proc-attr.patch
+++ b/debian/patches/change-security.selinux2-to-security.usec_proc-attr.patch
@@ -1,0 +1,34 @@
+From 23aa22ce36e6cd25ed3b7505ad05620d79ab1811 Mon Sep 17 00:00:00 2001
+From: zhouzilong <zhouzilong@uniontech.com>
+Date: Sat, 30 Nov 2024 11:28:19 +0800
+Subject: [PATCH] change security.selinux2 to security.usec_proc attr
+
+---
+ src/core/umac-access.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/core/umac-access.c b/src/core/umac-access.c
+index 4ecde3d..8f73f0c 100644
+--- a/src/core/umac-access.c
++++ b/src/core/umac-access.c
+@@ -30,7 +30,7 @@
+ 
+ static bool initialized = false;
+ 
+-#define DEFAULT_USID_CONTEXT	"root:sysadm_r:sysadm_t:s0"
++#define DEFAULT_USID_CONTEXT	"root:object_r:deepin_usec_t:s0"
+ 
+ /*
+    Any time an access gets denied this callback will be called
+@@ -139,7 +139,7 @@ static int mac_selinux_getfilecon2(const char *path, char **con) {
+                 if (context == NULL)
+                         return -ENOMEM;
+ 
+-                r = getxattr(path, "security.selinux2", context, MAX_USID);
++                r = getxattr(path, "security.usec_proc", context, MAX_USID);
+                 if (r <= 0) {
+                         free(context);
+                         context = NULL;
+-- 
+2.20.1
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -17,3 +17,4 @@ test-install-correct-kpartx-udev-rules-on-Debian.patch
 adapt-umac-of-usec.patch
 uniontech001-cancel-the-fsckd-check-prompt-at-boot-time.patch
 add-usecfs-magic.patch
+change-security.selinux2-to-security.usec_proc-attr.patch


### PR DESCRIPTION
usec support security.usec_proc attr, modify default usid context of systemd：

1. change security.selinux2 to security.usec_proc attr.
2. systemd default usid context is "root:object_r:deepin_usec_t:s0"