### PR TITLE
fix: enable log trace default

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+systemd (255.2-4deepin7) unstable; urgency=medium
+
+  * enable log trace default.
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Mon, 20 Jan 2025 15:18:01 +0800
+
 systemd (255.2-4deepin6) unstable; urgency=medium
 
   * fix usec status incorrect in umac_use().

--- a/debian/patches/fix-usec-status-incorrect-in-umac_use.patch
+++ b/debian/patches/fix-usec-status-incorrect-in-umac_use.patch
@@ -9,11 +9,11 @@ Change-Id: I641b7b08f72bd34aa37c80d52f9c4909df756c62
  src/shared/umac-util.c | 8 ++++++--
  2 files changed, 7 insertions(+), 3 deletions(-)
 
-diff --git a/src/core/umac-access.c b/src/core/umac-access.c
-index cabca5fb43..1b68e581a4 100644
---- a/src/core/umac-access.c
-+++ b/src/core/umac-access.c
-@@ -111,7 +111,7 @@ static int access_init2(sd_bus_error *error) {
+Index: deepin-systemd/src/core/umac-access.c
+===================================================================
+--- deepin-systemd.orig/src/core/umac-access.c	2025-01-20 15:16:08.000000000 +0800
++++ deepin-systemd/src/core/umac-access.c	2025-01-20 15:16:08.000000000 +0800
+@@ -111,7 +111,7 @@
                  int enforce, saved_errno = errno;
  
                  enforce = security_getenforce();
@@ -22,22 +22,23 @@ index cabca5fb43..1b68e581a4 100644
  
                  /* If enforcement isn't on, then let's suppress this
                   * error, and just don't do any AVC checks. The
-diff --git a/src/shared/umac-util.c b/src/shared/umac-util.c
-index 9f9c94cd7a..7b6b54ef31 100644
---- a/src/shared/umac-util.c
-+++ b/src/shared/umac-util.c
-@@ -2,8 +2,10 @@
+Index: deepin-systemd/src/shared/umac-util.c
+===================================================================
+--- deepin-systemd.orig/src/shared/umac-util.c	2025-01-20 15:16:08.000000000 +0800
++++ deepin-systemd/src/shared/umac-util.c	2025-01-20 15:16:41.884896561 +0800
+@@ -2,8 +2,11 @@
  
  #if HAVE_SELINUX
  #include <selinux/selinux.h>
 +#include <selinux/usec.h>
  #endif
  #include "umac-util.h"
++#include "string-util.h"
 +#include "log.h"
  
  #if HAVE_SELINUX
  static int cached_use = -1;
-@@ -11,8 +13,10 @@ static int cached_use = -1;
+@@ -11,8 +14,10 @@
  
  bool umac_use(void) {
  #if HAVE_SELINUX
@@ -50,6 +51,3 @@ index 9f9c94cd7a..7b6b54ef31 100644
  
          return cached_use;
  #else
--- 
-2.20.1
-

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -19,3 +19,4 @@ uniontech001-cancel-the-fsckd-check-prompt-at-boot-time.patch
 add-usecfs-magic.patch
 change-security.selinux2-to-security.usec_proc-attr.patch
 fix-usec-status-incorrect-in-umac_use.patch
+uniontech-enable-trace.patch

--- a/debian/patches/uniontech-enable-trace.patch
+++ b/debian/patches/uniontech-enable-trace.patch
@@ -1,0 +1,13 @@
+Index: deepin-systemd/meson_options.txt
+===================================================================
+--- deepin-systemd.orig/meson_options.txt	2025-01-20 14:52:46.099010069 +0800
++++ deepin-systemd/meson_options.txt	2025-01-20 15:04:54.088327274 +0800
+@@ -81,7 +81,7 @@
+        description : 'bump /proc/sys/fs/file-max to LONG_MAX')
+ option('bump-proc-sys-fs-nr-open', type : 'boolean',
+        description : 'bump /proc/sys/fs/nr_open to INT_MAX')
+-option('log-trace', type : 'boolean', value : false,
++option('log-trace', type : 'boolean', value : true,
+        description : 'enable low level debug logging')
+ option('user-path', type : 'string',
+        description : '$PATH to use for user sessions')


### PR DESCRIPTION
打开 log-trace的编译选项。 log_trace 在编译时候会define成log_debug，之后通过loglevel控制是否打印trace日志。
在v20 可以打trace日志。