### PR TITLE
fix: disable systemd-pstore

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+systemd (255.2-4deepin8) unstable; urgency=medium
+
+  * disable systemd-pstore.service.
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Fri, 28 Mar 2025 11:54:35 +0800
+
 systemd (255.2-4deepin7) unstable; urgency=medium
 
   * enable log trace default.

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -20,3 +20,4 @@ add-usecfs-magic.patch
 change-security.selinux2-to-security.usec_proc-attr.patch
 fix-usec-status-incorrect-in-umac_use.patch
 uniontech-enable-trace.patch
+uniontech-disable-systemd-pstore.patch

--- a/debian/patches/uniontech-disable-systemd-pstore.patch
+++ b/debian/patches/uniontech-disable-systemd-pstore.patch
@@ -1,0 +1,13 @@
+Index: deepin-systemd/presets/90-systemd.preset
+===================================================================
+--- deepin-systemd.orig/presets/90-systemd.preset	2025-01-20 14:52:46.107010433 +0800
++++ deepin-systemd/presets/90-systemd.preset	2025-03-28 11:53:07.455053247 +0800
+@@ -23,7 +23,7 @@
+ enable systemd-resolved.service
+ enable systemd-homed.service
+ enable systemd-userdbd.socket
+-enable systemd-pstore.service
++disable systemd-pstore.service
+ enable systemd-boot-update.service
+ enable systemd-journald-audit.socket
+ 

--- a/debian/systemd.postinst
+++ b/debian/systemd.postinst
@@ -51,8 +51,9 @@ fi
 if [ -z "$2" ]; then
     systemctl ${DPKG_ROOT:+--root="$DPKG_ROOT"} enable getty@tty1.service || true
     systemctl ${DPKG_ROOT:+--root="$DPKG_ROOT"} enable remote-fs.target || true
-    systemctl ${DPKG_ROOT:+--root="$DPKG_ROOT"} enable systemd-pstore.service || true
 fi
+
+systemctl ${DPKG_ROOT:+--root="$DPKG_ROOT"} disable systemd-pstore.service || true
 
 # Create /etc/machine-id
 systemd-machine-id-setup ${DPKG_ROOT:+--root="$DPKG_ROOT"}


### PR DESCRIPTION
Bug: 282983

新增开机自启服务需要架构评审，架构评审systemd-pstore服务不开机自启， 安装时将此服务disable。