### PR TITLE
Fix: add shutdown service to adjust time & add enable wol rule

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+systemd (255.2-4deepin9) unstable; urgency=medium
+
+  * add shutdown service.
+  * add enable wol rule.
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Tue, 29 Apr 2025 17:20:47 +0800
+
 systemd (255.2-4deepin8) unstable; urgency=medium
 
   * Disable seccomp support on mips64el.

--- a/debian/extra/rules-deepin/81-enable-wol.rules
+++ b/debian/extra/rules-deepin/81-enable-wol.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="net", NAME=="en*", PROGRAM=="/usr/bin/test -x /sbin/ethtool", RUN+="/sbin/ethtool -s $name wol g"

--- a/debian/extra/units-deepin/deepin-sys-shutdown.service
+++ b/debian/extra/units-deepin/deepin-sys-shutdown.service
@@ -1,0 +1,37 @@
+[Unit]
+Description=Special Cleanup Before File System Unmount During Shutdown/Reboot
+DefaultDependencies=no
+Before=umount.target
+Conflicts=suspend.target hibernate.target suspend-then-hibernate.target hybrid-sleep.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/deepin-sys-shutdown.sh
+RemainAfterExit=no
+TimeoutStopSec=10
+StandardOutput=journal
+StandardError=journal
+
+# Security Configuration
+ProtectSystem=strict
+ProtectHome=yes
+#can't use PrivateTmp=yes,will depend on tmp.mount and cannot be started when shutting down
+#PrivateTmp=yes
+PrivateNetwork=yes
+ProtectHostname=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=yes
+LockPersonality=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+RemoveIPC=yes
+
+# Allow writing to specific paths,because we need to call hwclock
+ReadWritePaths=/etc/adjtime
+
+[Install]
+WantedBy=poweroff.target reboot.target

--- a/debian/extra/units-deepin/deepin-sys-shutdown.sh
+++ b/debian/extra/units-deepin/deepin-sys-shutdown.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -e
+
+# Function to check if RTC is set to local time
+is_rtc_local() {
+    # Use grep to detect LOCAL keyword in /etc/adjtime
+    if [ -f /etc/adjtime ] && grep -q "LOCAL" /etc/adjtime; then
+        echo 1
+    else
+        echo 0
+    fi
+}
+
+# Get hardware clock time as timestamp
+get_hw_timestamp() {
+    local is_local="$1"
+    local hwtime_str
+    local args=("-r")
+
+    # Use -u if RTC is in UTC
+    if [ "$is_local" -eq 0 ]; then
+        args+=("-u")
+    fi
+
+    # Run hwclock and capture output
+    if ! hwtime_str=$(hwclock "${args[@]}"); then
+        echo "Failed to read hardware clock."
+        return 1
+    fi
+
+    # Convert to timestamp
+    local hw_timestamp
+    if ! hw_timestamp=$(date -d "$hwtime_str" +%s 2>/dev/null); then
+        echo "Failed to parse hardware clock output: $hwtime_str"
+        return 1
+    fi
+
+    # Return the timestamp
+    echo "$hw_timestamp"
+}
+
+# Main function to handle logic
+main() {
+    local is_local
+    local hw_timestamp
+    local system_timestamp
+    local diff_sec
+
+    # Detect if RTC uses local time
+    is_local=$(is_rtc_local)
+
+    # Get hardware clock timestamp
+    if ! hw_timestamp=$(get_hw_timestamp "$is_local"); then
+        echo "Skipping RTC adjustment due to error."
+        return 1
+    fi
+
+    # Get current system timestamp
+    if ! system_timestamp=$(date +%s 2>/dev/null); then
+        echo "Failed to get system timestamp."
+        return 1
+    fi
+
+    # Calculate difference
+    diff_sec=$((hw_timestamp - system_timestamp))
+
+    # If time difference is more than 5 seconds, write system time to RTC
+    if [ "$diff_sec" -gt 5 ] || [ "$diff_sec" -lt -5 ]; then
+        echo "Adjusting RTC..."
+        hwclock -w
+    fi
+}
+
+# Run main function with all script arguments
+main "$@"

--- a/debian/rules
+++ b/debian/rules
@@ -220,6 +220,11 @@ ifeq ($(DEB_VENDOR),Ubuntu)
 	cp -a debian/extra/units-ubuntu/* debian/systemd/usr/lib/systemd/system/
 endif
 
+	#deepin specific files
+	install --mode=644 debian/extra/rules-deepin/*.rules debian/udev/usr/lib/udev/rules.d/
+	install -D --mode=755 debian/extra/units-deepin/deepin-sys-shutdown.sh debian/systemd/usr/libexec/deepin-sys-shutdown.sh
+	install --mode=644 debian/extra/units-deepin/*.service debian/systemd/usr/lib/systemd/system/
+
 	# Remove empty directories from /usr/lib.
 	# Those are not strictly needed and can trigger piuparts errors due to
 	# accidential directory removal by dpkg on merged-/usr systems.
@@ -237,6 +242,9 @@ override_dh_installsystemd:
 	dh_installsystemd -psystemd-homed --no-also systemd-homed.service systemd-homed-activate.service
 	dh_installsystemd -psystemd-resolved
 	dh_installsystemd -pudev systemd-udevd.service
+
+	#enable deepin specific service
+	dh_installsystemd -psystemd --no-start deepin-sys-shutdown.service
 
 override_dh_installsystemduser:
 


### PR DESCRIPTION
Bug: 313885 288945

增加一个服务 deepin-sys-shutdown.service， 在关机时，在umount.target之前调用，用于调整rtc时间。 由于v25 文件系统是overlay，systemd的关机脚本在umount后调用，不起作用了，必须加这个服务。

增加一个rule用于enable wol。