### PR TITLE
Fix: make debug-shell need login in UOS

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+systemd (255.2-4deepin13) unstable; urgency=medium
+
+  * In Uos, the debug-shell should require a login to access.
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Thu, 25 Sep 2025 13:13:12 +0800
+
 systemd (255.2-4deepin12) unstable; urgency=medium
   
   * feat: add sw64 support

--- a/debian/control
+++ b/debian/control
@@ -75,6 +75,7 @@ Build-Depends: debhelper-compat (= 13),
                zstd <!nocheck>,
                gawk <!nocheck>,
                fdisk <!nocheck>,
+               lsb-release,
 
 Package: systemd
 Architecture: linux-any

--- a/debian/rules
+++ b/debian/rules
@@ -31,6 +31,12 @@ else
     GENSYMBOLS_LEVEL = 1
 endif
 
+ifeq (,$(filter uos Uos UOS,$(shell lsb_release -i -s)))
+    DEBUG_SHELL_FLAG = /usr/bin/bash
+else
+    DEBUG_SHELL_FLAG = "/sbin/agetty -o '-p -- \\\\\\\\u' --noclear - linux"
+endif
+
 CONFFLAGS = \
 	-Db_lto=true \
 	-Db_pie=true \
@@ -51,7 +57,7 @@ CONFFLAGS = \
 	-Dsysvinit-path=/etc/init.d \
 	-Dsysvrcnd-path=/etc \
 	-Dlocalegen-path=/usr/sbin/locale-gen \
-	-Ddebug-shell=/usr/bin/bash \
+	-Ddebug-shell=$(DEBUG_SHELL_FLAG) \
 	-Dzshcompletiondir=/usr/share/zsh/vendor-completions \
 	-Ddbuspolicydir=/usr/share/dbus-1/system.d/ \
 	-Dsupport-url=$(SUPPORT_URL) \


### PR DESCRIPTION
Bug: 334485

专业版设置debug shell需要登录才能使用。