### PR TITLE
Fix: add TPMFS_SUPER_MAGIC

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+systemd (255.2-4deepin14) unstable; urgency=medium
+
+  * support TPMFS_SUPER_MAGIC.
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Fri, 26 Sep 2025 17:13:54 +0800
+
 systemd (255.2-4deepin13) unstable; urgency=medium
 
   * In Uos, the debug-shell should require a login to access.

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -25,3 +25,4 @@ uniontech-disable-systemd-pstore.patch
 0002-basic-add-bcachefs-magic.patch
 uniontech-increase-ratelimit-of-mount.patch
 0001-deepin-sw_64-support.diff
+uniontech-add-tpmfs.patch

--- a/debian/patches/uniontech-add-tpmfs.patch
+++ b/debian/patches/uniontech-add-tpmfs.patch
@@ -1,0 +1,24 @@
+Index: deepin-systemd/src/basic/filesystems-gperf.gperf
+===================================================================
+--- deepin-systemd.orig/src/basic/filesystems-gperf.gperf	2025-09-26 17:12:03.000000000 +0800
++++ deepin-systemd/src/basic/filesystems-gperf.gperf	2025-09-26 17:13:44.591020062 +0800
+@@ -60,6 +60,7 @@
+ ext2,            {EXT2_SUPER_MAGIC}
+ ext3,            {EXT3_SUPER_MAGIC}
+ ext4,            {EXT4_SUPER_MAGIC}
++tpmfs,           {TPMFS_SUPER_MAGIC}
+ exfat,           {EXFAT_SUPER_MAGIC}
+ f2fs,            {F2FS_SUPER_MAGIC}
+ # fuseblk is so closely related to fuse that it shares the same magic
+Index: deepin-systemd/src/basic/generate-filesystem-switch-case.py
+===================================================================
+--- deepin-systemd.orig/src/basic/generate-filesystem-switch-case.py	2025-01-20 14:52:46.115010797 +0800
++++ deepin-systemd/src/basic/generate-filesystem-switch-case.py	2025-09-26 17:13:43.410968246 +0800
+@@ -14,6 +14,7 @@
+         "devtmpfs",  # not a file system of its own, but just a "named superblock" of tmpfs
+         "ext2",      # ext4 is the newest revision of ext2 + ext3
+         "ext3",
++        "tpmfs",
+         "fuseblk",   # closely related to fuse; they share a single magic, but the latter is more common
+         "gfs",       # magic taken over by gfs2
+         "msdos",     # vfat is the newest revision of msdos


### PR DESCRIPTION
Log: The kernel added TPMFS_SUPER_MAGIC, causing systemd to fail to compile.
     内核添加了TPMFS_SUPER_MAGIC，导致systemd编译不过