### PR TITLE
feat: optimize UOS-specific patching and disable mDNS by default

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+systemd (255.2-4deepin22) unstable; urgency=medium
+
+  * Adjust default MulticastDNS setting to 'no' in meson_options.txt.
+  * Add idempotent check for uniontech-add-tpmfs.patch to prevent
+    build failures on re-compilation.
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Thu, 05 Mar 2026 11:21:05 +0800
+
 systemd (255.2-4deepin21) unstable; urgency=medium
 
   * fix dbus read sysuser passwd

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -30,3 +30,4 @@ uniontech-increase-ratelimit-of-mount.patch
 uniontech-fix_zh_TW_HK_translation.patch
 uniontech-add-ug-bo-translation.patch
 uniontech-escape-spaces-when-serializing-as-well.patch
+uniontech-resolved-off-multidns.patch

--- a/debian/patches/uniontech-resolved-off-multidns.patch
+++ b/debian/patches/uniontech-resolved-off-multidns.patch
@@ -1,0 +1,13 @@
+Index: deepin-systemd/meson_options.txt
+===================================================================
+--- deepin-systemd.orig/meson_options.txt
++++ deepin-systemd/meson_options.txt
+@@ -338,7 +338,7 @@ option('default-dns-over-tls', type : 'c
+ option('default-mdns', type : 'combo',
+        choices : ['yes', 'resolve', 'no'],
+        description : 'default MulticastDNS mode',
+-       value : 'yes')
++       value : 'no')
+ option('default-llmnr', type : 'combo',
+        choices : ['yes', 'resolve', 'no'],
+        description : 'default LLMNR mode',

--- a/debian/rules
+++ b/debian/rules
@@ -162,7 +162,12 @@ endif
 override_dh_auto_configure:
 ifeq (yes,$(UOS_SYSTEM))
 	echo "UOS detected: applying uniontech-add-tpmfs.patch"
-	patch -p1 < debian/patches/uniontech-add-tpmfs.patch
+	if patch -p1 --dry-run -R < debian/patches/uniontech-add-tpmfs.patch >/dev/null 2>&1; then \
+        echo "UOS detected: patch already applied, skipping"; \
+    else \
+        echo "UOS detected: applying uniontech-add-tpmfs.patch"; \
+        patch -p1 < debian/patches/uniontech-add-tpmfs.patch; \
+    fi
 endif
 	dh_auto_configure \
 		-- $(CONFFLAGS) $(CONFFLAGS_DISTRO) $(CONFFLAGS_UPSTREAM)


### PR DESCRIPTION
- Improve `debian/rules` to conditionally apply `uniontech-add-tpmfs.patch` only when `UOS_SYSTEM=yes`.
- Add a pre-check using `patch --dry-run -R` to ensure the TPMFS patch is idempotent, preventing build errors during incremental or failed builds.
- Add `uniontech-resolved-off-multidns.patch` to disable MulticastDNS by default in systemd-resolved for consistent distribution behavior.

This ensures the TPMFS support (not present in Deepin) is safely managed during the UOS build process without breaking repetitive build environments.

feat: 优化 UOS 特定补丁处理逻辑并默认禁用 mDNS

- 改进 `debian/rules`，仅在 `UOS_SYSTEM=yes` 时应用 TPMFS 相关补丁。
- 引入 `patch --dry-run -R` 预检测机制，确保 TPMFS 补丁的操作幂等性， 避免在增量编译或失败重启编译时因重复打补丁而报错。
- 引入 `uniontech-resolved-off-multidns.patch` 以默认禁用 mDNS。

此举确保了 UOS 特有的 TPMFS 支持在构建过程中被安全管理，且不会干扰
Deepin 或重复构建的环境。