### PR TITLE
resolve: shorten PTR timeout for specific private ranges to avoid VMw…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+systemd (255.2-4deepin24) unstable; urgency=medium
+
+  * Optimized reverse DNS lookup timeout for 192.168.0.0/16 and link-local ranges.
+  * Fixed hangs in tools like route when running in virtualized environments
+    (e.g. VMware) with non-responsive DNS gateways.
+
+ -- 王鑫鹏 <ut003726@PEN202512100003>  Tue, 10 Mar 2026 10:11:38 +0800
+
 systemd (255.2-4deepin23) unstable; urgency=medium
 
   * add libusec.so to support USEC.

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -32,3 +32,4 @@ uniontech-add-ug-bo-translation.patch
 uniontech-escape-spaces-when-serializing-as-well.patch
 uniontech-resolved-off-multidns.patch
 uniontech-implement-USEC-with-libusec.patch
+uniontech-resolved-short-ptr-timeout.patch

--- a/debian/patches/uniontech-resolved-short-ptr-timeout.patch
+++ b/debian/patches/uniontech-resolved-short-ptr-timeout.patch
@@ -1,0 +1,50 @@
+Index: deepin-systemd/src/resolve/resolved-dns-query.c
+===================================================================
+--- deepin-systemd.orig/src/resolve/resolved-dns-query.c
++++ deepin-systemd/src/resolve/resolved-dns-query.c
+@@ -777,11 +777,44 @@ int dns_query_go(DnsQuery *q) {
+
+         dns_query_reset_answer(q);
+
++        /* --- Optimization to prevent hangs during reverse lookups in environments like VMware --- */
++        usec_t timeout_usec = SD_RESOLVED_QUERY_TIMEOUT_USEC;
++
++        if (IN_SET(q->request_family, AF_INET, AF_INET6)) {
++                bool is_problematic_range = false;
++
++                if (q->request_family == AF_INET) {
++                        uint32_t a = be32toh(q->request_address.in.s_addr);
++
++                        /* Focus ONLY on 192.168.0.0/16 and Link-Local.
++                        * 10.x.x.x and 172.x.x.x are left untouched as they are common in
++                        * enterprise intranets with functional DNS. */
++                        if ((a & 0xFFFF0000) == 0xC0A80000 ||           /* 192.168.0.0/16 (VMware/KVM default) */
++                            (a & 0xFFFF0000) == 0xA9FE0000)             /* 169.254.0.0/16 (Link-Local) */
++                                is_problematic_range = true;
++                } else if (q->request_family == AF_INET6) {
++                        /* IPv6 Link-Local (fe80::/10) is almost always safe to fail fast
++                        * if the local gateway doesn't respond instantly. */
++                        if ((q->request_address.in6.s6_addr[0] == 0xfe) &&
++                            ((q->request_address.in6.s6_addr[1] & 0xc0) == 0x80))
++                                is_problematic_range = true;
++                }
++
++                if (is_problematic_range) {
++                        /* Debug log to track why the timeout was shortened */
++                        log_warning("Detected VM-default or Link-Local address %s, using 2s timeout to avoid VMware hang.",
++                                IN_ADDR_TO_STRING(q->request_family, &q->request_address));
++
++                        timeout_usec = 2 * USEC_PER_SEC;
++                }
++        }
++        /* --- End of optimization --- */
++
+         r = event_reset_time_relative(
+                         q->manager->event,
+                         &q->timeout_event_source,
+                         CLOCK_BOOTTIME,
+-                        SD_RESOLVED_QUERY_TIMEOUT_USEC,
++                        timeout_usec,
+                         0, on_query_timeout, q,
+                         0, "query-timeout", true);
+         if (r < 0)


### PR DESCRIPTION
…are hang

In some virtualized environments (especially VMware), the local DNS gateway silently drops PTR queries for private IP ranges instead of returning NXDOMAIN. This causes systemd-resolved to retry and switch servers, leading to severe hangs (30s+) in synchronous tools like 'route', 'netstat', and 'ssh' via getnameinfo.

This patch detects reverse lookups for 192.168.0.0/16 and IPv4/IPv6 Link-Local addresses, applying a shortened 2-second timeout to ensure fast failure while maintaining compatibility with functional local DNS (like KVM).

在某些虚拟化环境（尤其是 VMware）中，本地 DNS 网关会直接丢弃私有网段的
PTR 反向解析请求而不返回任何响应。这导致 systemd-resolved 触发长时间重试，
使得 route、netstat 和 ssh 等依赖 getnameinfo 的工具出现严重卡顿（30秒以上）。

本补丁针对 192.168.0.0/16 及 IPv4/IPv6 Link-Local 地址的反向解析请求， 将超时时间缩短至 2 秒，在保证本地正常 DNS（如 KVM）可用的同时，实现快速失败，
解决虚拟机环境下的卡顿问题。