### PR TITLE
upstream-sleep: silence error message when homed is not installed

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+systemd (255.2-4deepin25) unstable; urgency=medium
+
+  * sleep: silence error message when homed is not installed
+
+ -- dongshengyuan <dongshengyuan@uniontech.com>  Mon, 16 Mar 2026 19:54:55 +0800
+
 systemd (255.2-4deepin24) unstable; urgency=medium
 
   * Optimized reverse DNS lookup timeout for 192.168.0.0/16 and link-local ranges.

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -33,3 +33,4 @@ uniontech-escape-spaces-when-serializing-as-well.patch
 uniontech-resolved-off-multidns.patch
 uniontech-implement-USEC-with-libusec.patch
 uniontech-resolved-short-ptr-timeout.patch
+upstream-silence-error-message-when-homed-is-not-installed.patch

--- a/debian/patches/upstream-silence-error-message-when-homed-is-not-installed.patch
+++ b/debian/patches/upstream-silence-error-message-when-homed-is-not-installed.patch
@@ -1,0 +1,13 @@
+--- a/src/shared/bus-util.c
++++ b/src/shared/bus-util.c
+@@ -174,8 +174,9 @@
+ 
+ bool bus_error_is_unknown_service(const sd_bus_error *error) {
+         return sd_bus_error_has_names(error,
+-                                      SD_BUS_ERROR_SERVICE_UNKNOWN,
+                                       SD_BUS_ERROR_NAME_HAS_NO_OWNER,
++                                      SD_BUS_ERROR_SERVICE_UNKNOWN,
++                                      SD_BUS_ERROR_UNKNOWN_OBJECT,
+                                       BUS_ERROR_NO_SUCH_UNIT);
+ }
+ 


### PR DESCRIPTION
Drawing inspiration from the upstream systemd to filter out this error message, UNKNOWN_OBECT was incorporated, effectively categorizing "service exists but object is gone" as "target unavailable" to reduce false positives and unnecessary errors.