### PR TITLE
fix: Disable wall broadcast messages by default

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+systemd (255.2-4deepin26) unstable; urgency=medium
+
+  * Disable wall broadcast messages by default, suppress "Broadcast message
+    from" and "The system will" notifications on scheduled shutdown/reboot.
+
+ -- zengwei <zengwei1@uniontech.com>  Wed, 30 Apr 2026 00:00:00 +0800
+
 systemd (255.2-4deepin25) unstable; urgency=medium
 
   * libnss-myhostname.nss: Install after `files`.

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -33,3 +33,4 @@ uniontech-escape-spaces-when-serializing-as-well.patch
 uniontech-resolved-off-multidns.patch
 uniontech-implement-USEC-with-libusec.patch
 uniontech-resolved-short-ptr-timeout.patch
+uniontech-disable-shutdown-wall-messages.patch

--- a/debian/patches/uniontech-disable-shutdown-wall-messages.patch
+++ b/debian/patches/uniontech-disable-shutdown-wall-messages.patch
@@ -1,0 +1,22 @@
+From: zengwei <zengwei@uniontech.com>
+Date: Wed, 30 Apr 2026 00:00:00 +0800
+Subject: [PATCH] disable wall broadcast messages by default
+
+Disable the "Broadcast message from" and "The system will" messages
+that logind sends to all terminals on scheduled shutdown/reboot.
+These messages are noise for end users. The shutdown info is still logged
+to the journal.
+
+diff --git a/src/login/logind.c b/src/login/logind.c
+index 88e05bb..9b1135a 100644
+--- a/src/login/logind.c
++++ b/src/login/logind.c
+@@ -63,7 +63,7 @@ static int manager_new(Manager **ret) {
+         *m = (Manager) {
+                 .console_active_fd = -EBADF,
+                 .reserve_vt_fd = -EBADF,
+-                .enable_wall_messages = true,
++                .enable_wall_messages = false,
+                 .idle_action_not_before_usec = now(CLOCK_MONOTONIC),
+         };
+ 


### PR DESCRIPTION
fix: Disable wall broadcast messages by default, suppress "Broadcast message
      from" and "The system will" notifications on scheduled shutdown/reboot.

pms: 356793