### PR TITLE
Fix: disable wall messages by default to suppress broadcast notifications on shutdown/reboot.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+systemd (255.2-4deepin27) unstable; urgency=medium
+
+  * systemctl: disable wall messages by default (set arg_no_wall to true)
+    to suppress broadcast notifications on shutdown/reboot.
+
+ -- zengwei <zengwei1@uniontech.com>  Tue, 13 May 2026 00:00:00 +0800
+
 systemd (255.2-4deepin26) unstable; urgency=medium
 
   * Disable wall broadcast messages by default, suppress "Broadcast message

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -34,3 +34,4 @@ uniontech-resolved-off-multidns.patch
 uniontech-implement-USEC-with-libusec.patch
 uniontech-resolved-short-ptr-timeout.patch
 uniontech-disable-shutdown-wall-messages.patch
+uniontech-systemctl-disable-wall.patch

--- a/debian/patches/uniontech-systemctl-disable-wall.patch
+++ b/debian/patches/uniontech-systemctl-disable-wall.patch
@@ -1,0 +1,29 @@
+From 84ff281b1bd75c7003df1a8828ce0f96bd026b56 Mon Sep 17 00:00:00 2001
+From: zengwei <zengwei1@uniontech.com>
+Date: Wed, 13 May 2026 14:10:01 +0800
+Subject: [PATCH] systemctl: disable wall messages by default
+
+Set arg_no_wall to true so that systemctl does not send wall
+broadcast messages on shutdown/reboot by default.
+
+---
+ src/systemctl/systemctl.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/systemctl/systemctl.c b/src/systemctl/systemctl.c
+index dd6f6c9873..074ec27047 100644
+--- a/src/systemctl/systemctl.c
++++ b/src/systemctl/systemctl.c
+@@ -79,7 +79,7 @@ int arg_legend = -1; /* -1: true, unless --quiet is passed, 1: true */
+ PagerFlags arg_pager_flags = 0;
+ bool arg_no_wtmp = false;
+ bool arg_no_sync = false;
+-bool arg_no_wall = false;
++bool arg_no_wall = true;
+ bool arg_no_reload = false;
+ BusPrintPropertyFlags arg_print_flags = 0;
+ bool arg_show_types = false;
+-- 
+2.50.1
+
+


### PR DESCRIPTION
Fix: disable wall messages by default to suppress broadcast notifications on shutdown/reboot.

pms:359543