### PR TITLE
fix: backport build system and compatibility fixes from upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ mkosi.local.conf
 /tags
 .dir-locals-2.el
 .vscode/
+.pc

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+systemd (255.2-4deepin28) stable; urgency=medium
+
+  * Backport upstream build and compatibility fixes:
+
+ -- Sisyphus <sisyphus@deepin.org>  Mon, 25 May 2026 17:39:32 +0800
+
 systemd (255.2-4deepin27) unstable; urgency=medium
 
   * systemctl: disable wall messages by default (set arg_no_wall to true)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -35,3 +35,10 @@ uniontech-implement-USEC-with-libusec.patch
 uniontech-resolved-short-ptr-timeout.patch
 uniontech-disable-shutdown-wall-messages.patch
 uniontech-systemctl-disable-wall.patch
+upstream-math-util-round-to-declared-FP-precision.patch
+upstream-replace-exp10-with-own-impl.patch
+upstream-math-util-drop-libm-where-possible.patch
+upstream-base-filesystem-powerpc-ifdef.patch
+upstream-base-filesystem-hppa-ifdef.patch
+upstream-meson-fs-relative_to.patch
+upstream-po-skip-automated-fuzzy-translations.patch

--- a/debian/patches/upstream-base-filesystem-hppa-ifdef.patch
+++ b/debian/patches/upstream-base-filesystem-hppa-ifdef.patch
@@ -1,0 +1,14 @@
+diff --git a/src/shared/base-filesystem.c b/src/shared/base-filesystem.c
+index 9e8856ba48..8546f389b1 100644
+--- a/src/shared/base-filesystem.c
++++ b/src/shared/base-filesystem.c
+@@ -76,6 +76,9 @@ static const BaseFilesystem table[] = {
+ #elif defined(__arm__)
+         /* No /lib64 on arm. The linker is /lib/ld-linux-armhf.so.3. */
+ #  define KNOW_LIB64_DIRS 1
++#elif defined(__hppa__)
++        /* No /lib32 or /lib64 on hppa. The linker is /usr/lib/hppa-linux-gnu/ld.so.1. */
++#  define KNOW_LIB64_DIRS 1
+ #elif defined(__i386__) || defined(__x86_64__)
+         { "lib64",    0, "usr/lib64\0"
+                          "usr/lib\0",                "ld-linux-x86-64.so.2" },

--- a/debian/patches/upstream-base-filesystem-powerpc-ifdef.patch
+++ b/debian/patches/upstream-base-filesystem-powerpc-ifdef.patch
@@ -1,0 +1,13 @@
+diff --git a/src/shared/base-filesystem.c b/src/shared/base-filesystem.c
+index 8546f389b1..79d2f00ebd 100644
+--- a/src/shared/base-filesystem.c
++++ b/src/shared/base-filesystem.c
+@@ -117,6 +117,8 @@ static const BaseFilesystem table[] = {
+         /* powerpc64-linux-gnu */
+ #  else
+         /* powerpc-linux-gnu */
++        /* No /lib32 or /lib64 on powerpc. The linker is /usr/lib/powerpc-linux-gnu/ld.so.1. */
++#       define KNOW_LIB64_DIRS 1
+ #  endif
+ #elif defined(__riscv)
+ #  if __riscv_xlen == 32

--- a/debian/patches/upstream-math-util-drop-libm-where-possible.patch
+++ b/debian/patches/upstream-math-util-drop-libm-where-possible.patch
@@ -1,0 +1,139 @@
+Index: deepin-systemd-pr4/meson.build
+===================================================================
+--- deepin-systemd-pr4.orig/meson.build
++++ deepin-systemd-pr4/meson.build
+@@ -381,6 +381,11 @@ possible_common_cc_flags = [
+         '-fstack-protector',
+         '-fstack-protector-strong',
+         '-fstrict-flex-arrays',
++        # We don't read errno from any libm call, and the math-errno fallback
++        # forces a DT_NEEDED on libm via the cold error path even when the hot
++        # path is a single hardware instruction (sqrtsd, etc.). Drop it so the
++        # builtins lower to pure hardware instructions.
++        '-fno-math-errno',
+         '--param=ssp-buffer-size=4',
+ ]
+ 
+Index: deepin-systemd-pr4/src/basic/meson.build
+===================================================================
+--- deepin-systemd-pr4.orig/src/basic/meson.build
++++ deepin-systemd-pr4/src/basic/meson.build
+@@ -273,7 +273,6 @@ libbasic = static_library(
+         fundamental_sources,
+         include_directories : basic_includes,
+         dependencies : [libcap,
+-                        libm,
+                         librt,
+                         threads,
+                         userspace],
+Index: deepin-systemd-pr4/src/libsystemd/meson.build
+===================================================================
+--- deepin-systemd-pr4.orig/src/libsystemd/meson.build
++++ deepin-systemd-pr4/src/libsystemd/meson.build
+@@ -205,7 +205,6 @@ libsystemd_tests += [
+                         libgio,
+                         libglib,
+                         libgobject,
+-                        libm,
+                         threads,
+                 ],
+         },
+Index: deepin-systemd-pr4/src/pcrlock/meson.build
+===================================================================
+--- deepin-systemd-pr4.orig/src/pcrlock/meson.build
++++ deepin-systemd-pr4/src/pcrlock/meson.build
+@@ -13,7 +13,6 @@ executables += [
+                         'pehash.c',
+                 ),
+                 'dependencies' : [
+-                        libm,
+                         libopenssl,
+                         tpm2,
+                 ],
+Index: deepin-systemd-pr4/src/test/meson.build
+===================================================================
+--- deepin-systemd-pr4.orig/src/test/meson.build
++++ deepin-systemd-pr4/src/test/meson.build
+@@ -368,7 +368,6 @@ executables += [
+         },
+         test_template + {
+                 'sources' : files('test-parse-util.c'),
+-                'dependencies' : libm,
+         },
+         test_template + {
+                 'sources' : files('test-process-util.c'),
+@@ -380,7 +379,6 @@ executables += [
+         },
+         test_template + {
+                 'sources' : files('test-random-util.c'),
+-                'dependencies' : libm,
+                 'timeout' : 120,
+         },
+         test_template + {
+Index: deepin-systemd-pr4/src/test/test-random-util.c
+===================================================================
+--- deepin-systemd-pr4.orig/src/test/test-random-util.c
++++ deepin-systemd-pr4/src/test/test-random-util.c
+@@ -1,7 +1,5 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ 
+-#include <math.h>
+-
+ #include "hexdecoct.h"
+ #include "log.h"
+ #include "memory-util.h"
+@@ -15,7 +13,7 @@ TEST(random_bytes) {
+         for (size_t i = 1; i < sizeof buf; i++) {
+                 random_bytes(buf, i);
+                 if (i + 1 < sizeof buf)
+-                        assert_se(buf[i] == 0);
++                        ASSERT_EQ(buf[i], 0);
+ 
+                 hexdump(stdout, buf, i);
+         }
+@@ -25,9 +23,9 @@ TEST(crypto_random_bytes) {
+         uint8_t buf[16] = {};
+ 
+         for (size_t i = 1; i < sizeof buf; i++) {
+-                assert_se(crypto_random_bytes(buf, i) == 0);
++                ASSERT_OK(crypto_random_bytes(buf, i));
+                 if (i + 1 < sizeof buf)
+-                        assert_se(buf[i] == 0);
++                        ASSERT_EQ(buf[i], 0);
+ 
+                 hexdump(stdout, buf, i);
+         }
+@@ -53,21 +51,25 @@ static void test_random_u64_range_one(un
+         /* Print histogram: vertical axis — value, horizontal axis — count.
+          *
+          * The expected value is always TOTAL/mod, because the distribution should be flat. The expected
+-         * variance is TOTAL×p×(1-p), where p==1/mod, and standard deviation the root of the variance.
+-         * Assert that the deviation from the expected value is less than 6 standard deviations.
++         * variance is TOTAL×p×(1-p), where p==1/mod. Assert that the deviation from the expected value
++         * is less than 6 standard deviations by comparing squared values (diff² < 36·variance), which
++         * avoids a sqrt() call and the libm dependency that comes with it at -O0.
+          */
+         unsigned scale = 2 * max / (columns() < 20 ? 80 : columns() - 20);
+         double exp = (double) TOTAL / mod;
++        double variance = exp * (mod > 1 ? mod - 1 : 1) / mod;
+ 
+         for (size_t i = 0; i < mod; i++) {
+-                double dev = (count[i] - exp) / sqrt(exp * (mod > 1 ? mod - 1 : 1) / mod);
+-                log_debug("%02zu: %5u (%+.3f)%*s",
+-                          i, count[i], dev,
++                double diff = count[i] - exp;
++                double dev_sq = diff * diff / variance;
++
++                log_debug("%02zu: %5u (z²=%.3f)%*s",
++                          i, count[i], dev_sq,
+                           (int) (count[i] / scale), "x");
+ 
+-                assert_se(fabs(dev) < 6); /* 6 sigma is excessive, but this check should be enough to
+-                                           * identify catastrophic failure while minimizing false
+-                                           * positives. */
++                ASSERT_TRUE(dev_sq < 36); /* 36 = 6²; 6 sigma is excessive, but this check should be
++                                           * enough to identify catastrophic failure while minimizing
++                                           * false positives. */
+         }
+ }
+ 

--- a/debian/patches/upstream-math-util-round-to-declared-FP-precision.patch
+++ b/debian/patches/upstream-math-util-round-to-declared-FP-precision.patch
@@ -1,0 +1,67 @@
+Index: deepin-systemd-pr4/meson.build
+===================================================================
+--- deepin-systemd-pr4.orig/meson.build
++++ deepin-systemd-pr4/meson.build
+@@ -376,6 +376,7 @@ possible_common_cc_flags = [
+         '-Wno-string-plus-int',  # clang
+ 
+         '-fdiagnostics-show-option',
++        '-fexcess-precision=standard',
+         '-fno-common',
+         '-fstack-protector',
+         '-fstack-protector-strong',
+Index: deepin-systemd-pr4/src/basic/math-util.h
+===================================================================
+--- deepin-systemd-pr4.orig/src/basic/math-util.h
++++ deepin-systemd-pr4/src/basic/math-util.h
+@@ -10,5 +10,19 @@
+ #define iszero_safe(x) (fpclassify(x) == FP_ZERO)
+ 
+ /* To avoid x == y and triggering compile warning -Wfloat-equal. This returns false if one of the argument is
+- * NaN or infinity. One of the argument must be a floating point. */
+-#define fp_equal(x, y) iszero_safe((x) - (y))
++ * NaN or infinity. One of the argument must be a floating point.
++ *
++ * The volatile temporaries force a memory roundtrip, truncating any excess precision (e.g. x87's
++ * 80-bit register width for double arithmetic) down to the declared type. -fexcess-precision=standard
++ * doesn't fully cover this on x87 — a function return value carried in ST(0) can still arrive at the
++ * caller in 80-bit precision (see gcc PR#323), so a value that should compare equal to a
++ * same-magnitude literal picks up extra mantissa bits and doesn't. The memory store-and-reload is
++ * the one operation guaranteed to truncate. The temporaries inherit the type of the subtraction
++ * expression so the macro stays generic over float / double / long double rather than silently
++ * truncating wider arguments. */
++#define fp_equal(x, y)                                                  \
++        ({                                                              \
++                volatile __typeof__((x) - (y)) _fp_x = (x);             \
++                volatile __typeof__((x) - (y)) _fp_y = (y);             \
++                iszero_safe(_fp_x - _fp_y);                             \
++        })
+Index: deepin-systemd-pr4/src/test/test-math-util.c
+===================================================================
+--- deepin-systemd-pr4.orig/src/test/test-math-util.c
++++ deepin-systemd-pr4/src/test/test-math-util.c
+@@ -5,6 +5,15 @@
+ #include "math-util.h"
+ #include "tests.h"
+ 
++/* Computed at runtime via a noinline + volatile combination so the result crosses the function ABI
++ * boundary at the FPU's current precision (80-bit on i386/x87). Used to probe fp_equal's handling
++ * of excess precision — see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=323 for why
++ * -fexcess-precision=standard doesn't fully cover the caller side of a function return on x87. */
++static double _noinline_ one_tenth_via_division(void) {
++        volatile double ten = 10.0;
++        return 1.0 / ten;
++}
++
+ TEST(iszero_safe) {
+         /* zeros */
+         assert_se(iszero_safe(0.0));
+@@ -105,6 +114,8 @@ TEST(fp_equal) {
+         assert_se( fp_equal(0, 1 / INFINITY));
+         assert_se( fp_equal(42 / INFINITY, 1 / -INFINITY));
+         assert_se(!fp_equal(42 / INFINITY, INFINITY / INFINITY));
++
++        assert_se( fp_equal(one_tenth_via_division(), 0.1));
+ }
+ 
+ DEFINE_TEST_MAIN(LOG_DEBUG);

--- a/debian/patches/upstream-meson-fs-relative_to.patch
+++ b/debian/patches/upstream-meson-fs-relative_to.patch
@@ -1,0 +1,31 @@
+Index: deepin-systemd-pr4/meson.build
+===================================================================
+--- deepin-systemd-pr4.orig/meson.build
++++ deepin-systemd-pr4/meson.build
+@@ -29,6 +29,18 @@ relative_source_path = run_command('real
+                                    '--relative-to=@0@'.format(project_build_root),
+                                    project_source_root,
+                                    check : true).stdout().strip()
++
++fs = import('fs')
++
++if meson.version().version_compare('>=1.3.0')
++        relative_source_path = fs.relative_to(project_source_root,
++                                              project_build_root)
++else
++        relative_source_path = run_command('realpath',
++                                           '--relative-to=@0@'.format(project_build_root),
++                                           project_source_root,
++                                           check : true).stdout().strip()
++endif
+ conf.set_quoted('RELATIVE_SOURCE_PATH', relative_source_path)
+ 
+ conf.set10('BUILD_MODE_DEVELOPER', get_option('mode') == 'developer',
+@@ -75,7 +87,6 @@ endif
+ 
+ #####################################################################
+ 
+-fs = import('fs')
+ if get_option('split-bin') == 'auto'
+         split_bin = not fs.is_symlink('/usr/sbin')
+ else

--- a/debian/patches/upstream-po-skip-automated-fuzzy-translations.patch
+++ b/debian/patches/upstream-po-skip-automated-fuzzy-translations.patch
@@ -1,0 +1,39 @@
+diff --git a/po/meson.build b/po/meson.build
+index 0a140b40b5..682c16ab11 100644
+--- a/po/meson.build
++++ b/po/meson.build
+@@ -3,6 +3,12 @@
+ want_translations = get_option('translations')
+ 
+ if want_translations
++        # The msgmerge invocation hidden behind i18n.gettext()'s update-po target inserts auto-guessed
++        # "fuzzy" translations for new strings, which are almost always wrong, use a wrapper to skip it.
++        meson.override_find_program(
++                'msgmerge',
++                find_program('../tools/msgmerge-no-fuzzy.py'))
++
+         i18n = import('i18n')
+         i18n.gettext(meson.project_name(),
+                      preset : 'glib',
+diff --git a/tools/msgmerge-no-fuzzy.py b/tools/msgmerge-no-fuzzy.py
+new file mode 100755
+index 0000000000..a9171db695
+--- /dev/null
++++ b/tools/msgmerge-no-fuzzy.py
+@@ -0,0 +1,16 @@
++#!/usr/bin/env python3
++# SPDX-License-Identifier: LGPL-2.1-or-later
++"""
++Fuzzy translations are always bogus, but the meson integration doesn't allow overriding. With this wrapper
++we can skip them.
++"""
++
++import os
++import shutil
++import sys
++
++msgmerge = shutil.which('msgmerge')
++if msgmerge is None:
++    sys.exit('msgmerge-no-fuzzy: msgmerge not found in PATH')
++
++os.execv(msgmerge, [msgmerge, '--no-fuzzy-matching', *sys.argv[1:]])

--- a/debian/patches/upstream-replace-exp10-with-own-impl.patch
+++ b/debian/patches/upstream-replace-exp10-with-own-impl.patch
@@ -1,0 +1,98 @@
+Index: deepin-systemd-pr4/src/basic/math-util.c
+===================================================================
+--- /dev/null
++++ deepin-systemd-pr4/src/basic/math-util.c
+@@ -0,0 +1,24 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++
++#include "math-util.h"
++
++double xexp10i(int n) {
++        /* Powers of 10 up to 10^22 are exact in IEEE-754 binary64. */
++        static const double table[] = {
++                1e0,  1e1,  1e2,  1e3,  1e4,  1e5,  1e6,  1e7,  1e8,  1e9,  1e10, 1e11,
++                1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19, 1e20, 1e21, 1e22,
++        };
++        bool negative = n < 0;
++
++        /* Cast before negation so n == INT_MIN doesn't invoke signed-overflow UB. Unsigned negation
++         * wraps to the magnitude we want. */
++        unsigned k = negative ? -(unsigned) n : (unsigned) n;
++
++        /* 10^309 already overflows binary64 to +Inf; anything beyond just stays there. */
++        k = MIN(k, 309u);
++        double r = k < ELEMENTSOF(table) ? table[k] : table[ELEMENTSOF(table) - 1];
++        for (unsigned i = ELEMENTSOF(table) - 1; i < k; i++)
++                r *= 10.0;
++
++        return negative ? 1.0 / r : r;
++}
+Index: deepin-systemd-pr4/src/basic/math-util.h
+===================================================================
+--- deepin-systemd-pr4.orig/src/basic/math-util.h
++++ deepin-systemd-pr4/src/basic/math-util.h
+@@ -26,3 +26,8 @@
+                 volatile __typeof__((x) - (y)) _fp_y = (y);             \
+                 iszero_safe(_fp_x - _fp_y);                             \
+         })
++
++/* 10^n. Exact for |n| ≤ 22; otherwise multiplies and may accumulate rounding error. Saturates to
++ * 0.0 or +Inf outside binary64's exponent range; large |n| is capped internally so untrusted
++ * inputs can't cause unbounded work. */
++double xexp10i(int n);
+Index: deepin-systemd-pr4/src/basic/meson.build
+===================================================================
+--- deepin-systemd-pr4.orig/src/basic/meson.build
++++ deepin-systemd-pr4/src/basic/meson.build
+@@ -53,6 +53,7 @@ basic_sources = files(
+         'lock-util.c',
+         'log.c',
+         'login-util.c',
++        'math-util.c',
+         'memfd-util.c',
+         'memory-util.c',
+         'mempool.c',
+Index: deepin-systemd-pr4/src/test/test-math-util.c
+===================================================================
+--- deepin-systemd-pr4.orig/src/test/test-math-util.c
++++ deepin-systemd-pr4/src/test/test-math-util.c
+@@ -118,4 +118,39 @@ TEST(fp_equal) {
+         assert_se( fp_equal(one_tenth_via_division(), 0.1));
+ }
+ 
++TEST(xexp10i) {
++        /* Table-lookup range: every value is exact in binary64 */
++        ASSERT_TRUE(fp_equal(xexp10i(0), 1.0));
++        ASSERT_TRUE(fp_equal(xexp10i(1), 10.0));
++        ASSERT_TRUE(fp_equal(xexp10i(2), 100.0));
++        ASSERT_TRUE(fp_equal(xexp10i(22), 1e22));
++
++        /* Negative exponents */
++        ASSERT_TRUE(fp_equal(xexp10i(-1), 0.1));
++        ASSERT_TRUE(fp_equal(xexp10i(-3), 0.001));
++
++        /* Beyond the table: result still matches a plain 10.0 multiplication chain (no precision
++         * claim beyond binary64) */
++        ASSERT_TRUE(xexp10i(23) > 0.9e23 && xexp10i(23) < 1.1e23);
++        ASSERT_TRUE(xexp10i(100) > 0.9e100 && xexp10i(100) < 1.1e100);
++
++        /* Overflow saturates to +Inf, underflow to 0 — matching glibc exp10() */
++        ASSERT_TRUE(isinf(xexp10i(400)));
++        ASSERT_TRUE(fp_equal(xexp10i(-400), 0.0));
++
++        /* Pathological inputs must still terminate quickly thanks to the internal cap */
++        ASSERT_TRUE(isinf(xexp10i(INT_MAX)));
++        ASSERT_TRUE(fp_equal(xexp10i(INT_MIN), 0.0));
++
++        /* Regression guard for the DBL_MAX round-trip described in math-util.c: 10^308 must be small
++         * enough that DBL_MAX's mantissa (≈ 1.7976931348623157) multiplied by it does not overflow
++         * to +Inf. Delegating to __builtin_powi(10.0, n) here breaks this — libgcc's __powidf2
++         * accumulates a few ULPs of error through repeated squaring, and the product spills over.
++         * Matching test-json's delta of 0.0001, the reconstructed value must land within 0.01% of
++         * DBL_MAX. */
++        double dbl_max_reconstructed = 1.7976931348623157 * xexp10i(308);
++        ASSERT_FALSE(isinf(dbl_max_reconstructed));
++        ASSERT_TRUE(ABS(1.0 - DBL_MAX / dbl_max_reconstructed) < 0.0001);
++}
++
+ DEFINE_TEST_MAIN(LOG_DEBUG);


### PR DESCRIPTION
## Summary

Backport selected upstream patches (systemd main branch) to improve build compatibility and reduce external dependencies.

## Changes

### Applied patches (7)
| Patch | Description |
|-------|-------------|
| `56bc502` | math-util: round to declared FP precision via volatile temporaries |
| `d52c8f2` | tree-wide: replace exp10() with own xexp10i() implementation |
| `933a458` | basic/math-util: drop libm where possible (-fno-math-errno) |
| `23d3d07` | base-filesystem: add powerpc ifdef branch |
| `d61ce0c` | base-filesystem: add hppa ifdef branch |
| `e32656c` | meson: use fs.relative_to() instead of realpath (meson >= 1.3.0) |
| `d3f38e0` | po: skip automated fuzzy translations via msgmerge-no-fuzzy.py |

### Skipped patches (6)
- `8e7665f` — Bump minimum musl to 1.2.6 (no diff content from lensup)
- `12b9760` — musl: drop statx definitions (musl files not in Debian tree)
- `bc40f6c` — musl: drop renameat2() wrapper (musl files not in Debian tree)
- `997ce3a` — po: detect msgmerge-nofuzzy (different po/meson.build structure)
- `580bd17` — Use malloc'ed strings for user/group lookup (no diff content)
- `788ef4c` — meson: limit test-link-abi to developer mode (test not present)

### Conflict resolution
- Adapted `meson.build` fs.relative_to() for our variable naming (`project_source_root` vs `meson.project_source_root()`)
- Adapted libm removal for our meson.build structure (different dependency ordering)
- Replaced `sqrt`/`fabs` with squared comparison in test-random-util.c to match our `fabs(dev)` context

## Version
`255.2-4deepin28`

## Testing
- `quilt push -a` passes for all 42 patches (35 existing + 7 new)
- No `.rej` files remaining after conflict resolution