### PR TITLE
fix: backport security vulnerability patches from upstream

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+systemd (255.2-4deepin28) stable; urgency=medium
+
+  * Backport upstream critical security vulnerability patches:
+  * aa76d811: resolved: add missing polkit checks for
+    FlushCaches/ResetServerFeatures
+  * e7cd836d: resolved: cap pre-allocation for questions/RRs to prevent
+    DNS memory exhaustion
+  * 9b217384: sd-bus: add depth limit to message_skip_fields() to
+    prevent stack overflow via variant recursion
+  * b45a897e: sd-hwdb: reject out-of-bounds fnmatch prefixes to prevent
+    OOB read
+  * 4e02162a: core/exec-invoke: chdir after chroot to prevent CWD escape
+
+ -- jiabowen <jiabowen@uniontech.com>  Mon, 25 May 2026 17:32:05 +0800
+
 systemd (255.2-4deepin27) unstable; urgency=medium
 
   * systemctl: disable wall messages by default (set arg_no_wall to true)

--- a/debian/patches/exec-invoke-chdir-after-chroot.patch
+++ b/debian/patches/exec-invoke-chdir-after-chroot.patch
@@ -1,0 +1,62 @@
+From 4e02162a6e88a38e509e0646d6d39f14a8e14490 Mon Sep 17 00:00:00 2001
+From: Chris Mason <clm@meta.com>
+Date: Fri, 22 May 2026 08:49:27 -0700
+Subject: [PATCH] core/exec-invoke: chdir("/") after chroot in
+ apply_root_directory
+
+apply_root_directory() calls chroot() but never pairs it with a
+chdir("/"). Moving cwd into the new root is left to the subsequent
+apply_working_directory() call. That delegation breaks when the unit
+sets WorkingDirectory=-/path (working_directory_missing_ok):
+
+    apply_root_directory()              apply_working_directory()
+      chroot(new_root)        -->         chdir(wd) fails (ENOENT)
+      return 0                            return 0  /* missing_ok */
+
+chroot(2) changes only the process root, not cwd. With cwd still
+resolving to the pre-chroot host dentry, the process runs with the
+kernel root pointing at the new root while relative-path accesses
+and /proc/self/cwd reach paths outside RootDirectory=.
+
+Only the chroot-only branch (exec_needs_mount_namespace() == false)
+is affected. The mount-namespace branch uses pivot_root(), which
+restructures the mount tree and makes the pre-chroot dentry
+unreachable.
+
+Fix by issuing chdir("/") immediately after the successful chroot()
+in apply_root_directory() and propagating any failure with
+EXIT_CHROOT, matching the standard chroot+chdir idiom and making
+the chroot self-contained regardless of how
+apply_working_directory() later handles a missing directory.
+
+Assisted-by: kres (claude-opus-4-7)
+Signed-off-by: Chris Mason <clm@meta.com>
+
+Index: deepin-systemd-pr1/src/core/exec-invoke.c
+===================================================================
+--- deepin-systemd-pr1.orig/src/core/exec-invoke.c
++++ deepin-systemd-pr1/src/core/exec-invoke.c
+@@ -3275,12 +3275,22 @@ static int apply_root_directory(
+         assert(exit_status);
+ 
+         if (params->flags & EXEC_APPLY_CHROOT)
+-                if (!needs_mount_ns && context->root_directory)
++                if (!needs_mount_ns && context->root_directory) {
+                         if (chroot((runtime ? runtime->ephemeral_copy : NULL) ?: context->root_directory) < 0) {
+                                 *exit_status = EXIT_CHROOT;
+                                 return -errno;
+                         }
+ 
++                        /* chroot(2) changes only the process root, not cwd. Move cwd into the new root
++                         * immediately so that a subsequent apply_working_directory() failure that is
++                         * silently ignored via working_directory_missing_ok cannot leave cwd pointing
++                         * at a pre-chroot dentry outside the new root. */
++                        if (chdir("/") < 0) {
++                                *exit_status = EXIT_CHROOT;
++                                return -errno;
++                        }
++                }
++
+         return 0;
+ }
+ 

--- a/debian/patches/hwdb-reject-oob-fnmatch.patch
+++ b/debian/patches/hwdb-reject-oob-fnmatch.patch
@@ -1,0 +1,38 @@
+From b45a897edc1a11b8cf2f876f00dbb73f82fe5b6a Mon Sep 17 00:00:00 2001
+From: Luca Boccassi <luca.boccassi@gmail.com>
+Date: Thu, 21 May 2026 23:24:32 +0100
+Subject: [PATCH] hwdb: reject out-of-bounds fnmatch prefixes
+
+Ensure that fnmatch traversal doesn't go off the hwdb.bin in case of
+a corrupted file
+
+Originally reported on yeswehack.com as #YWH-PGM9780-70
+
+For the unit test:
+Co-developed-by: GitHub Copilot <github-copilot[bot]@users.noreply.github.com>
+
+Index: deepin-systemd-pr1/src/libsystemd/sd-hwdb/sd-hwdb.c
+===================================================================
+--- deepin-systemd-pr1.orig/src/libsystemd/sd-hwdb/sd-hwdb.c
++++ deepin-systemd-pr1/src/libsystemd/sd-hwdb/sd-hwdb.c
+@@ -186,9 +186,18 @@ static int trie_fnmatch_f(sd_hwdb *hwdb,
+         const char *prefix;
+         int err;
+ 
++        assert(hwdb);
++        assert(node);
++
++        /* Ensure the prefix is within bounds */
++        uint64_t file_size = hwdb->st.st_size, prefix_off = le64toh(node->prefix_off);
++        if (prefix_off >= file_size || p >= file_size - prefix_off)
++                return -EINVAL;
++
+         prefix = trie_string(hwdb, node->prefix_off);
+-        len = strlen(prefix + p);
+-        linebuf_add(buf, prefix + p, len);
++        len = strnlen(prefix + p, file_size - prefix_off - p);
++        if (!linebuf_add(buf, prefix + p, len))
++                return -EINVAL;
+ 
+         for (i = 0; i < node->children_count; i++) {
+                 const struct trie_child_entry_f *child = trie_node_child(hwdb, node, i);

--- a/debian/patches/resolved-dns-memory-exhaustion.patch
+++ b/debian/patches/resolved-dns-memory-exhaustion.patch
@@ -1,0 +1,115 @@
+From e7cd836dcffb5f85d66a156904fc68f8b654a290 Mon Sep 17 00:00:00 2001
+From: Frantisek Sumsal <frantisek@sumsal.cz>
+Date: Tue, 19 May 2026 14:51:56 +0200
+Subject: [PATCH] resolve: cap pre-allocation for questions/RRs
+
+Since [0] and [1] questions & answer RRs from the incoming packets are
+parsed into a hashmap to speed things up. The hashmaps are even
+pre-allocated to speed things up even more, but there's one caveat - the
+size for the pre-allocation comes from one or more fields from the
+incoming packets that are under sender's control.
+
+This can be abused by a malicious DNS server which can send a packet
+with a spoofed QDCOUNT (for question packets) or ANCOUNT/NSCOUNT/ARCOUNT
+(for answer packets). The limit of the final value in both cases is 64K.
+This value is then used to pre-allocate the hashmap (via
+set_reserve()/ordered_set_reserve(), where the caller also multiplies
+the input value by 2 in both cases), which in turns calls
+resize_buckets() that memzero()s the pre-allocated area, so all the
+pages are faulted in, showing in process' RSS. Each such spoofed packet
+then can translate into a ~4 MiB allocation in the systemd-resolved
+process, which doesn't sound that bad.
+
+However, this can be further amplified if the spoofed packet ends up in
+resolved's cache. So, if the spoofed packet contains one valid A record
+and then an OPT record with a spoofed ARCOUNT, the whole packet ends up
+in the cache that can hold 4K of entries, which can eventually cause
+resolved to keep up to 16 GiB of memory just for the cache (and thanks
+to the memzero() above it's all RSS). Note that all this requires
+someone with enough privileges to configure resolved to actually point
+to such malicious DNS server or it could come from a malicious DHCP
+server on the network. This could also get exploited via LLMNR, but in
+thas case an attacker would have to match an ID of a valid transaction
+for the packet to end up in resolved's cache.
+
+For example, with a malicious DNS already in resolved configuration:
+
+$ resolvectl dns eth0
+Link 2 (eth0): 192.168.99.1:5354
+
+Filling resolved's cache:
+
+$ for i in {0..4200}; do resolvectl query test-$i.example.com; done
+...
+test-4200.example.com: 192.0.2.1               -- link: dummy0
+
+-- Information acquired via protocol DNS in 1.6ms.
+-- Data is authenticated: no; Data was acquired via local or encrypted transport: no
+-- Data from: network
+
+Yields following memory increase:
+
+$ while :; do grep VmRSS /proc/$(pidof systemd-resolved)/status; sleep 1; done
+VmRSS:     14280 kB
+VmRSS:     14280 kB
+...
+VmRSS:    403352 kB
+VmRSS:   1017976 kB
+VmRSS:   1603876 kB
+VmRSS:   2202028 kB
+...
+VmRSS:  16795724 kB
+VmRSS:  16795724 kB
+
+In my testing I also noticed one annoyance - after certain threshold the
+RSS increase persisted even after the malicious entries were evicted
+from the cache (or flushed via `resolvectl flush-caches`). This was most
+likely due to mmap_threshold getting bumped to > 4 MiB and neither cache
+eviction nor flush-caches call malloc_trim(0) (via
+sd_event_trim_memory() or similar).
+
+To mitigate this, let's cap the pre-allocation to a maximum number of
+records the given packet body can realistically contain. If the minimum
+size would be, for whatever unlikely reason, not enough, nothing serious
+would happen - the hashmap would still get resized automatically by
+resize_buckets(), it'd be just slightly slower.
+
+[0] ae45e1a3832fbb6c96707687e42f0b4aaab52c9b
+[1] 2d34cf0c16dd8fa71fb593e65ce4734cb61d9170
+
+Index: deepin-systemd-pr1/src/resolve/resolved-dns-packet.c
+===================================================================
+--- deepin-systemd-pr1.orig/src/resolve/resolved-dns-packet.c
++++ deepin-systemd-pr1/src/resolve/resolved-dns-packet.c
+@@ -2208,8 +2208,15 @@ static int dns_packet_extract_question(D
+                 if (!keys)
+                         return log_oom();
+ 
+-                r = set_reserve(keys, n * 2); /* Higher multipliers give slightly higher efficiency through
+-                                               * hash collisions, but the gains quickly drop off after 2. */
++                /* Pre-allocate the question hashmap, but cap the pre-allocation to a number of questions the
++                 * packet can realistically contain. That is, pick the minimal value from the claimed number
++                 * of questions (n) and a maximum number of potential questions the remaining packet data can
++                 * actually contain: p->size - p->rindex are the remaining unread bytes in the packet, and 5U
++                 * is the minimum size of each question - 1 (QNAME) + 2 (QTYPE) + 2 (QCLASS).
++                 *
++                 * Note for the multiplication: higher multipliers give slightly higher efficiency through
++                 * hash collisions, but the gains quickly drop off after 2. */
++                r = set_reserve(keys, MIN(n, (p->size - p->rindex) / 5U) * 2);
+                 if (r < 0)
+                         return r;
+ 
+@@ -2253,7 +2260,12 @@ static int dns_packet_extract_answer(Dns
+         if (n == 0)
+                 return 0;
+ 
+-        answer = dns_answer_new(n);
++        /* Pre-allocate the answer hashmap, but cap the pre-allocation to a number of RRs the packet can
++         * realistically contain. That is, pick the minimal value from the claimed number of RRs (n) and a
++         * maximum number of potential RRs the remaining packet data can actually contain: p->size -
++         * p->rindex are the remaining unread bytes in the packet, and the 11U is the minimum size of each RR
++         * - 1 (NAME) + 2 (TYPE) + 2 (CLASS) + 4 (TTL) + 2 (RDLENGTH). */
++        answer = dns_answer_new(MIN(n, (p->size - p->rindex) / 11U));
+         if (!answer)
+                 return -ENOMEM;
+ 

--- a/debian/patches/resolved-polkit-checks.patch
+++ b/debian/patches/resolved-polkit-checks.patch
@@ -1,0 +1,101 @@
+From aa76d81122a1db488c7116cf44d949f07b8fb198 Mon Sep 17 00:00:00 2001
+From: TristanInSec <tristan.mtn@gmail.com>
+Date: Mon, 18 May 2026 13:30:51 -0400
+Subject: [PATCH] resolved: add missing polkit checks on FlushCaches and
+ ResetServerFeatures D-Bus methods
+
+The FlushCaches and ResetServerFeatures D-Bus methods perform
+destructive operations (flushing all DNS caches and resetting server
+feature negotiation including DNS-over-TLS state) without any
+authorization check. The corresponding Varlink methods already enforce
+polkit via verify_polkit(), but the D-Bus handlers were not updated.
+
+Add bus_verify_polkit_async() calls to both methods, matching the
+pattern used by ResetStatistics. Add the corresponding policy actions
+to the polkit policy file.
+
+Index: deepin-systemd-pr1/src/resolve/org.freedesktop.resolve1.policy
+===================================================================
+--- deepin-systemd-pr1.orig/src/resolve/org.freedesktop.resolve1.policy
++++ deepin-systemd-pr1/src/resolve/org.freedesktop.resolve1.policy
+@@ -139,4 +139,26 @@
+                 <annotate key="org.freedesktop.policykit.owner">unix-user:systemd-resolve</annotate>
+         </action>
+ 
++        <action id="org.freedesktop.resolve1.flush-caches">
++                <description gettext-domain="systemd">Flush DNS caches</description>
++                <message gettext-domain="systemd">Authentication is required to flush DNS caches.</message>
++                <defaults>
++                        <allow_any>auth_admin</allow_any>
++                        <allow_inactive>auth_admin</allow_inactive>
++                        <allow_active>auth_admin_keep</allow_active>
++                </defaults>
++                <annotate key="org.freedesktop.policykit.owner">unix-user:systemd-resolve</annotate>
++        </action>
++
++        <action id="org.freedesktop.resolve1.reset-server-features">
++                <description gettext-domain="systemd">Reset server features</description>
++                <message gettext-domain="systemd">Authentication is required to reset server features.</message>
++                <defaults>
++                        <allow_any>auth_admin</allow_any>
++                        <allow_inactive>auth_admin</allow_inactive>
++                        <allow_active>auth_admin_keep</allow_active>
++                </defaults>
++                <annotate key="org.freedesktop.policykit.owner">unix-user:systemd-resolve</annotate>
++        </action>
++
+ </policyconfig>
+Index: deepin-systemd-pr1/src/resolve/resolved-bus.c
+===================================================================
+--- deepin-systemd-pr1.orig/src/resolve/resolved-bus.c
++++ deepin-systemd-pr1/src/resolve/resolved-bus.c
+@@ -1815,9 +1815,24 @@ static int bus_method_get_link(sd_bus_me
+ 
+ static int bus_method_flush_caches(sd_bus_message *message, void *userdata, sd_bus_error *error) {
+         Manager *m = ASSERT_PTR(userdata);
++        int r;
+ 
+         assert(message);
+ 
++        r = bus_verify_polkit_async(
++                        message,
++                        CAP_SYS_ADMIN,
++                        "org.freedesktop.resolve1.flush-caches",
++                        NULL,
++                        false,
++                        UID_INVALID,
++                        &m->polkit_registry,
++                        error);
++        if (r < 0)
++                return r;
++        if (r == 0)
++                return 1; /* Polkit will call us back */
++
+         bus_client_log(message, "cache flush");
+ 
+         manager_flush_caches(m, LOG_INFO);
+@@ -1827,9 +1842,24 @@ static int bus_method_flush_caches(sd_bu
+ 
+ static int bus_method_reset_server_features(sd_bus_message *message, void *userdata, sd_bus_error *error) {
+         Manager *m = ASSERT_PTR(userdata);
++        int r;
+ 
+         assert(message);
+ 
++        r = bus_verify_polkit_async(
++                        message,
++                        CAP_SYS_ADMIN,
++                        "org.freedesktop.resolve1.reset-server-features",
++                        NULL,
++                        false,
++                        UID_INVALID,
++                        &m->polkit_registry,
++                        error);
++        if (r < 0)
++                return r;
++        if (r == 0)
++                return 1; /* Polkit will call us back */
++
+         bus_client_log(message, "server feature reset");
+ 
+         manager_reset_server_features(m);

--- a/debian/patches/sdbus-depth-limit-variant.patch
+++ b/debian/patches/sdbus-depth-limit-variant.patch
@@ -1,0 +1,76 @@
+From 9b21738498affe2b7ec477be1b55e79a052d852f Mon Sep 17 00:00:00 2001
+From: TristanInSec <tristan.mtn@gmail.com>
+Date: Tue, 19 May 2026 17:33:06 -0400
+Subject: [PATCH] sd-bus: add depth limit to message_skip_fields() to prevent
+ stack overflow
+
+message_skip_fields() recurses for each nested variant ('v') type in
+D-Bus message header fields. A crafted message with deeply nested
+variants (e.g., a variant containing a variant containing a variant...)
+causes unbounded stack growth, leading to stack overflow and crash.
+
+Add a depth parameter that increments on each recursive call and
+rejects messages exceeding BUS_CONTAINER_DEPTH with -EBADMSG. This
+matches the existing depth limits enforced elsewhere in the sd-bus
+message processing (e.g., bus_message_enter_container).
+
+Index: deepin-systemd-pr1/src/libsystemd/sd-bus/bus-message.c
+===================================================================
+--- deepin-systemd-pr1.orig/src/libsystemd/sd-bus/bus-message.c
++++ deepin-systemd-pr1/src/libsystemd/sd-bus/bus-message.c
+@@ -3891,7 +3891,8 @@ static int message_skip_fields(
+                 sd_bus_message *m,
+                 size_t *ri,
+                 uint32_t array_size,
+-                const char **signature) {
++                const char **signature,
++                unsigned depth) {
+ 
+         size_t original_index;
+         int r;
+@@ -3900,6 +3901,9 @@ static int message_skip_fields(
+         assert(ri);
+         assert(signature);
+ 
++        if (depth >= BUS_CONTAINER_DEPTH)
++                return log_debug_errno(SYNTHETIC_ERRNO(EBADMSG), "Maximum container nesting depth reached, refusing.");
++
+         original_index = *ri;
+ 
+         for (;;) {
+@@ -3980,7 +3984,7 @@ static int message_skip_fields(
+                                 if (r < 0)
+                                         return r;
+ 
+-                                r = message_skip_fields(m, ri, nas, (const char**) &s);
++                                r = message_skip_fields(m, ri, nas, (const char**) &s, depth + 1);
+                                 if (r < 0)
+                                         return r;
+                         }
+@@ -3994,7 +3998,7 @@ static int message_skip_fields(
+                         if (r < 0)
+                                 return r;
+ 
+-                        r = message_skip_fields(m, ri, UINT32_MAX, (const char**) &s);
++                        r = message_skip_fields(m, ri, UINT32_MAX, (const char**) &s, depth + 1);
+                         if (r < 0)
+                                 return r;
+ 
+@@ -4012,7 +4016,7 @@ static int message_skip_fields(
+                                 strncpy(sig, *signature + 1, l);
+                                 sig[l] = '\0';
+ 
+-                                r = message_skip_fields(m, ri, UINT32_MAX, (const char**) &s);
++                                r = message_skip_fields(m, ri, UINT32_MAX, (const char**) &s, depth + 1);
+                                 if (r < 0)
+                                         return r;
+                         }
+@@ -4186,7 +4190,7 @@ static int message_parse_fields(sd_bus_m
+                         break;
+ 
+                 default:
+-                        r = message_skip_fields(m, &ri, UINT32_MAX, (const char **) &signature);
++                        r = message_skip_fields(m, &ri, UINT32_MAX, (const char **) &signature, 0);
+                 }
+                 if (r < 0)
+                         return r;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -35,3 +35,8 @@ uniontech-implement-USEC-with-libusec.patch
 uniontech-resolved-short-ptr-timeout.patch
 uniontech-disable-shutdown-wall-messages.patch
 uniontech-systemctl-disable-wall.patch
+resolved-polkit-checks.patch
+resolved-dns-memory-exhaustion.patch
+sdbus-depth-limit-variant.patch
+hwdb-reject-oob-fnmatch.patch
+exec-invoke-chdir-after-chroot.patch


### PR DESCRIPTION
Backport critical security fixes from upstream systemd (2026-05-19 ~ 2026-05-25).
## Patches Applied (5)
- **resolved: polkit bypass** - add missing polkit checks on FlushCaches/ResetServerServices
  Upstream: https://github.com/systemd/systemd/commit/aa76d81122a1db488c7116cf44d949f07b8fb198
- **resolve: memory exhaustion** - cap pre-allocation for DNS questions/RRs
  Upstream: https://github.com/systemd/systemd/commit/e7cd836dcffb5f85d66a156904fc68f8b654a290
- **sd-bus: stack overflow** - add depth limit to message_skip_fields for variant recursion
  Upstream: https://github.com/systemd/systemd/commit/9b21738498affe2b7ec477be1b55e79a052d852f
- **hwdb: OOB read** - reject out-of-bounds fnmatch prefixes
  Upstream: https://github.com/systemd/systemd/commit/b45a897edc1a11b8cf2f876f00dbb73f82fe5b6a
- **exec-invoke: chroot escape** - chdir after chroot to prevent CWD escape
  Upstream: https://github.com/systemd/systemd/commit/4e02162a6e88a38e509e0646d6d39f14a8e14490
## Skipped (files not present in this version)
- nsresourced: user namespace identity - nsresourced not in this build
  Upstream: https://github.com/systemd/systemd/commit/01e6465b
- qmp-client: fiber UAF - fiber code not yet in this version
  Upstream: https://github.com/systemd/systemd/commit/37679d79
- dissect-image: int64 overflow + fd leak - dissect-image differs
  Upstream: https://github.com/systemd/systemd/commit/2eff8375
  Upstream: https://github.com/systemd/systemd/commit/f134bca6
- sd-bus: general depth limit - overlaps with variant version
  Upstream: https://github.com/systemd/systemd/commit/ce260a11
- boot/stub: SMBIOS TPM - stub files differ
  Upstream: https://github.com/systemd/systemd/commit/2f2203c2
## Test Plan
- [x] `quilt push -a` succeeds cleanly
- [x] `dpkg-buildpackage` builds successfully