### PR TITLE
fix(basic/path-util): fix executable_is_good detection - add missing comma in PATH_IN_SET

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+systemd (255.2-4deepin29) stable; urgency=medium
+
+  * Backport upstream fix: basic/path-util: fix executable_is_good  The
+    PATH_IN_SET macro in executable_is_good() was missing a comma
+    between string literals, causing adjacent string concatenation
+    ("true" "/bin/true" -> "true/bin/true") and breaking fsck detection
+    for /bin/true symlinks. Reported by qarmin (Rafał Mikrut).
+
+ -- jiabowen <jiabowen@uniontech.com>  Thu, 28 May 2026 16:26:37 +0800
+
 systemd (255.2-4deepin28) stable; urgency=medium
 
   * Backport upstream critical security vulnerability patches:

--- a/debian/patches/fix-executable-is-good.patch
+++ b/debian/patches/fix-executable-is-good.patch
@@ -1,0 +1,13 @@
+Index: systemd/src/basic/path-util.c
+===================================================================
+--- systemd.orig/src/basic/path-util.c
++++ systemd/src/basic/path-util.c
+@@ -793,7 +793,7 @@ static int executable_is_good(const char
+         if (r < 0)
+                 return r;
+ 
+-        return !PATH_IN_SET(d, "true"
++        return !PATH_IN_SET(d, "true",
+                                "/bin/true",
+                                "/usr/bin/true",
+                                "/dev/null");

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -40,3 +40,4 @@ resolved-dns-memory-exhaustion.patch
 sdbus-depth-limit-variant.patch
 hwdb-reject-oob-fnmatch.patch
 exec-invoke-chdir-after-chroot.patch
+fix-executable-is-good.patch


### PR DESCRIPTION
Backport critical fix from upstream systemd.

## Patch

- **basic/path-util**: fix executable_is_good detection
  Upstream: [systemd/systemd@92e0c920](https://github.com/systemd/systemd/commit/92e0c920c7e4ad99a9a0b388038e38588e251559)

## Test Plan

- quilt push -a succeeds cleanly (Debian only)
- dpkg-buildpackage builds successfully (Debian only)