### PR TITLE
skip clock restore

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+systemd (255.2-4deepin29) unstable; urgency=medium
+
+  * Skip clock restore for timesyncd.
+
+ -- dongshengyuan <dongshengyuan@uniontech.com>  Mon, 01 Jun 2026 17:06:06 +0800
+
 systemd (255.2-4deepin28) stable; urgency=medium
 
   * Backport upstream critical security vulnerability patches:

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -40,3 +40,4 @@ resolved-dns-memory-exhaustion.patch
 sdbus-depth-limit-variant.patch
 hwdb-reject-oob-fnmatch.patch
 exec-invoke-chdir-after-chroot.patch
+uniontech-skip-clock-restore-for-timesyncd.patch

--- a/debian/patches/uniontech-skip-clock-restore-for-timesyncd.patch
+++ b/debian/patches/uniontech-skip-clock-restore-for-timesyncd.patch
@@ -1,0 +1,25 @@
+Index: systemd/src/timesync/timesyncd.c
+===================================================================
+--- systemd.orig/src/timesync/timesyncd.c
++++ systemd/src/timesync/timesyncd.c
+@@ -124,6 +124,12 @@ static int load_clock_timestamp(uid_t ui
+         /* Not that it matters much, but we actually restore the clock to n+1 here rather than n, simply
+          * because we read n as time previously already and we want to progress here, i.e. not report the
+          * same time again. */
++        /* Disabled: clock restore and structured log are skipped intentionally.
++         * The system clock adjustment via clock_settime() and the corresponding
++         * SD_MESSAGE_TIME_BUMP log_struct() have been commented out to prevent
++         * automatic clock correction on this build. */
++        log_debug("Skipping clock restore and TIME_BUMP log: ct=" USEC_FMT " min=" USEC_FMT, ct, min);
++#if 0
+         if (clock_settime(CLOCK_REALTIME, TIMESPEC_STORE(min+1)) < 0) {
+                 log_warning_errno(errno, "Failed to restore system clock, ignoring: %m");
+                 return 0;
+@@ -134,6 +140,7 @@ static int load_clock_timestamp(uid_t ui
+                    "REALTIME_USEC=" USEC_FMT, min+1,
+                    LOG_MESSAGE("System clock time unset or jumped backwards, restored from recorded timestamp: %s",
+                                FORMAT_TIMESTAMP(min+1)));
++#endif
+         return 0;
+ }
+ 


### PR DESCRIPTION
Disabled: clock restore and structured log are skipped intentionally.
* The system clock adjustment via clock_settime() and the corresponding
* SD_MESSAGE_TIME_BUMP log_struct() have been commented out to prevent
* automatic clock correction on this build. 