### PR TITLE
fix(telinit): backport upstream telinit compatibility hint and man page cleanup

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+systemd (255.2-4deepin29+deepin1) unstable; urgency=medium
+
+  * Backport upstream telinit compatibility hint and man page cleanup
+    patches
+
+ -- 贾博闻 <ut006444@PECI2782>  Tue, 02 Jun 2026 15:32:46 +0800
+
 systemd (255.2-4deepin29) unstable; urgency=medium
 
   * Skip clock restore for timesyncd.

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -41,3 +41,4 @@ sdbus-depth-limit-variant.patch
 hwdb-reject-oob-fnmatch.patch
 exec-invoke-chdir-after-chroot.patch
 uniontech-skip-clock-restore-for-timesyncd.patch
+telinit-compat-hint.patch

--- a/debian/patches/telinit-compat-hint.patch
+++ b/debian/patches/telinit-compat-hint.patch
@@ -1,0 +1,182 @@
+From ff1721325dfdf76640130513e7a14b4c08291f35 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zbigniew=20J=C4=99drzejewski-Szmek?= <zbyszek@amutable.com>
+Date: Sat, 30 May 2026 21:44:58 +0200
+Subject: [PATCH 1/4] man/systemd: reword description of 2/3/4/5
+
+We shouldn't say that that they boot into "a … legacy target", because
+they boot into the standard targets. Those names are just aliases now.
+(And also the user is not required to know what SysV even is, so it
+shouldn't be used in the main explanation.)
+
+From 0f990a8ab95d7b433066f3efc466b314147aebb4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zbigniew=20J=C4=99drzejewski-Szmek?= <zbyszek@amutable.com>
+Date: Mon, 1 Jun 2026 12:21:12 +0200
+Subject: [PATCH 2/4] man: drop -b/s/S/2/4 from the docs
+
+We retain 1/3/5.
+
+From b1410258f8dfcb6a3cdaad17b716e4f76a4e4db3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Zbigniew=20J=C4=99drzejewski-Szmek?= <zbyszek@amutable.com>
+Date: Sun, 31 May 2026 12:29:01 +0200
+Subject: [PATCH 3/4] manager: if called with compat telinit interface, tell
+ users to update
+
+In https://bugzilla.redhat.com/show_bug.cgi?id=2479961 a user
+reported that they are confused that 'init 6' and such commands
+do not work anymore. We removed support for the whole interface,
+but it's likely that such commands persist in various scripts
+and finger memories. Let's give a helpful hint that this inteface
+is gone and what to use instead.
+
+Index: deepin-systemd-pr1/man/systemd.xml
+===================================================================
+--- deepin-systemd-pr1.orig/man/systemd.xml
++++ deepin-systemd-pr1/man/systemd.xml
+@@ -1031,12 +1031,11 @@
+       <varlistentry>
+         <term><varname>emergency</varname></term>
+         <term><varname>rd.emergency</varname></term>
+-        <term><varname>-b</varname></term>
+ 
+-        <listitem><para>Boot into emergency mode. This is equivalent
+-        to <varname>systemd.unit=emergency.target</varname> or
+-        <varname>rd.systemd.unit=emergency.target</varname>, respectively, and
+-        provided for compatibility reasons and to be easier to type.</para>
++        <listitem><para>Boot into emergency mode. Those options are equivalent to
++        <varname>systemd.unit=emergency.target</varname> or
++        <varname>rd.systemd.unit=emergency.target</varname>, respectively. They were initially
++        provided for compatibility with SysV, but are retained as convenient shortcuts.</para>
+ 
+         <xi:include href="version-info.xml" xpointer="v186"/></listitem>
+       </varlistentry>
+@@ -1045,32 +1044,25 @@
+         <term><varname>rescue</varname></term>
+         <term><varname>rd.rescue</varname></term>
+         <term><varname>single</varname></term>
+-        <term><varname>s</varname></term>
+-        <term><varname>S</varname></term>
+         <term><varname>1</varname></term>
+ 
+-        <listitem><para>Boot into rescue mode. This is equivalent to
+-        <varname>systemd.unit=rescue.target</varname> or
+-        <varname>rd.systemd.unit=rescue.target</varname>, respectively, and
+-        provided for compatibility reasons and to be easier to type.</para>
++        <listitem><para>Boot into rescue mode. Those options are equivalent to either
++        <varname>systemd.unit=rescue.target</varname> or <varname>rd.systemd.unit=rescue.target</varname>.
++        They were initially provided for compatibility with SysV, but are retained as convenient
++        shortcuts.</para>
+ 
+         <xi:include href="version-info.xml" xpointer="v186"/></listitem>
+       </varlistentry>
+ 
+       <varlistentry>
+-        <term><varname>2</varname></term>
+         <term><varname>3</varname></term>
+-        <term><varname>4</varname></term>
+         <term><varname>5</varname></term>
+ 
+-        <listitem><para>Boot into the specified legacy SysV runlevel.
+-        These are equivalent to
+-        <varname>systemd.unit=runlevel2.target</varname>,
+-        <varname>systemd.unit=runlevel3.target</varname>,
+-        <varname>systemd.unit=runlevel4.target</varname>, and
+-        <varname>systemd.unit=runlevel5.target</varname>,
+-        respectively, and provided for compatibility reasons and to be
+-        easier to type.</para>
++        <listitem><para>Shortcuts to boot into specific targets:
++        <varname>3</varname> is equivalent to
++        <varname>systemd.unit=multi-user.target</varname> and <varname>5</varname> is equivalent to
++        <varname>systemd.unit=graphical.target</varname>. Those options were initially provided
++        for compatibility with SysV, but are retained as convenient shortcuts.</para>
+ 
+         <xi:include href="version-info.xml" xpointer="v186"/></listitem>
+       </varlistentry>
+Index: deepin-systemd-pr1/src/core/main.c
+===================================================================
+--- deepin-systemd-pr1.orig/src/core/main.c
++++ deepin-systemd-pr1/src/core/main.c
+@@ -1442,19 +1442,39 @@ static int fixup_environment(void) {
+ }
+ 
+ static void redirect_telinit(int argc, char *argv[]) {
+-
+-        /* This is compatibility support for SysV, where calling init as a user is identical to telinit. */
++        /* Check if we are invoked through the legacy interface, where init would be symlinked as telinit
++         * and allow users to call 'init 0' and such. If we detect such use, tell the user that this is not
++         * supported anymore. */
+ 
+ #if HAVE_SYSV_COMPAT
+-        if (getpid_cached() == 1)
++        if (getpid_cached() == 1 || !invoked_as(argv, "init"))
+                 return;
+ 
+-        if (!invoked_as(argv, "init"))
++        /* Build the list of legacy telinit commands from the arguments.
++         * The first argument is the program name, so skip it. */
++        _cleanup_strv_free_ char **args = NULL;
++        args = strv_new(NULL);
++        if (!args)
+                 return;
++        for (int i = 1; i < argc; i++) {
++                if (strv_push(&args, argv[i]) < 0)
++                        return;
++        }
++
++        if (!strv_overlap(args,
++                          STRV_MAKE("0", "1", "2", "3", "4", "5", "6",
++                                    "s", "S", "q", "Q", "u", "U")))
++                return;
++
++        _cleanup_free_ char *a = NULL, *b = NULL, *c = NULL;
++        (void) terminal_urlify_man_full("shutdown", "8", /* suffix= */ NULL, &a);
++        (void) terminal_urlify_man_full("reboot", "8", /* suffix= */ NULL, &b);
++        (void) terminal_urlify_man_full("systemctl", "1", /* suffix= */ NULL, &c);
+ 
+-        execv(SYSTEMCTL_BINARY_PATH, argv);
+-        log_error_errno(errno, "Failed to exec " SYSTEMCTL_BINARY_PATH ": %m");
+-        exit(EXIT_FAILURE);
++        log_error_errno(SYNTHETIC_ERRNO(EOPNOTSUPP),
++                       "Program 'systemd' called as 'init' with a legacy telinit command.\n"
++                       "Call %s, %s, or %s instead.",
++                       strnull(a), strnull(b), strnull(c));
+ #endif
+ }
+ 
+Index: deepin-systemd-pr1/src/shared/pretty-print.c
+===================================================================
+--- deepin-systemd-pr1.orig/src/shared/pretty-print.c
++++ deepin-systemd-pr1/src/shared/pretty-print.c
+@@ -158,15 +158,19 @@ int terminal_urlify_path(const char *pa
+         return terminal_urlify(url, text, ret);
+ }
+ 
+-int terminal_urlify_man(const char *page, const char *section, char **ret) {
++int terminal_urlify_man_full(const char *page, const char *section, const char *suffix, char **ret) {
+         const char *url, *text;
+ 
+         url = strjoina("man:", page, "(", section, ")");
+-        text = strjoina(page, "(", section, ") man page");
++        text = strjoina(page, "(", section, ")", suffix);
+ 
+         return terminal_urlify(url, text, ret);
+ }
+ 
++int terminal_urlify_man(const char *page, const char *section, char **ret) {
++        return terminal_urlify_man_full(page, section, " man page", ret);
++}
++
+ typedef enum {
+         LINE_SECTION,
+         LINE_COMMENT,
+Index: deepin-systemd-pr1/src/shared/pretty-print.h
+===================================================================
+--- deepin-systemd-pr1.orig/src/shared/pretty-print.h
++++ deepin-systemd-pr1/src/shared/pretty-print.h
+@@ -16,6 +16,7 @@ bool urlify_enabled(void);
+ 
+ int terminal_urlify(const char *url, const char *text, char **ret);
+ int terminal_urlify_path(const char *path, const char *text, char **ret);
++int terminal_urlify_man_full(const char *page, const char *section, const char *suffix, char **ret);
+ int terminal_urlify_man(const char *page, const char *section, char **ret);
+ 
+ typedef enum CatFlags {


### PR DESCRIPTION
## Summary

Backport upstream patches that improve telinit legacy interface handling and clean up kernel command line documentation.

## Backported Commits

- `ff1721325dfdf76640130513e7a14b4c08291f35` - man/systemd: reword description of 2/3/4/5
- `0f990a8ab95d7b433066f3efc466b314147aebb4` - man: drop -b/s/S/2/4 from the docs (retain 1/3/5)
- `b1410258f8dfcb6a3cdaad17b716e4f76a4e4db3` - manager: if called with compat telinit interface, tell users to update
- `f75bf007f973b485401136dc09bc3448c067649a` - Emit a hint when called with the legacy telinit syntax (squash commit, no diff)

## Changes

### man/systemd.xml
- Reword kernel command line option descriptions (emergency, rescue, multi-user targets)
- Drop deprecated shortcuts `-b`, `s`, `S`, `2`, `4` from documentation
- Retain `1`, `3`, `5` as convenient shortcuts
- Replace legacy `runlevelN.target` references with standard target names

### src/core/main.c
- Replace `execv`-based telinit redirect with error hint
- Print helpful message directing users to `shutdown(8)`, `reboot(8)`, `systemctl(1)`

### src/shared/pretty-print
- Add `terminal_urlify_man_full()` with custom suffix support
- Preserve existing `terminal_urlify_man()` as wrapper

## Upstream
- https://github.com/systemd/systemd/commit/ff1721325dfdf76640130513e7a14b4c08291f35
- https://github.com/systemd/systemd/commit/0f990a8ab95d7b433066f3efc466b314147aebb4
- https://github.com/systemd/systemd/commit/b1410258f8dfcb6a3cdaad17b716e4f76a4e4db3
- https://github.com/systemd/systemd/commit/f75bf007f973b485401136dc09bc3448c067649a