### PR TITLE
perf(initramfs): optimize udev trigger and root device wait strategy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+systemd (255.2-4deepin31) unstable; urgency=medium
+
+  * Optimize udev trigger priority and replace full settle with
+  * root-device-only wait.
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Fri, 12 Jun 2026 17:31:08 +0800
+
 systemd (255.2-4deepin30) unstable; urgency=medium
 
   * Fix tmpfiles x11 socket age-based cleanup causing unexpected removal

--- a/debian/extra/initramfs-tools/scripts/init-top/udev
+++ b/debian/extra/initramfs-tools/scripts/init-top/udev
@@ -23,20 +23,43 @@ fi
 
 SYSTEMD_LOG_LEVEL=$log_level /usr/lib/systemd/systemd-udevd --daemon --resolve-names=never
 
-udevadm trigger --type=subsystems --action=add
-udevadm trigger --type=devices --action=add
+udevadm trigger --type=all --action=add --prioritized-subsystem=block,drm
 
-# Not use udevadm settle to wait
-#udevadm settle || true
-root_uuid=${ROOT#UUID=}
-for i in $( seq 1 25 )
-do
-        rootdev="$(blkid --uuid "${root_uuid}")"
-        if [ -n "${rootdev}" ];then
-                break
-        fi
-                sleep 0.2
-done
+# Dynamic Root Path Resolution: Parse the target root path using pure shell string manipulation.
+# This avoids deadlocks caused by invoking 'blkid' or 'findfs' before devices are fully probed.
+WAIT_TARGET=""
+if [ -n "$ROOT" ]; then
+    case "$ROOT" in
+        UUID=*)
+            WAIT_TARGET="/dev/disk/by-uuid/${ROOT#UUID=}"
+            ;;
+        PARTUUID=*)
+            WAIT_TARGET="/dev/disk/by-partuuid/${ROOT#PARTUUID=}"
+            ;;
+        LABEL=*)
+            WAIT_TARGET="/dev/disk/by-label/${ROOT#LABEL=}"
+            ;;
+        PARTLABEL=*)
+            WAIT_TARGET="/dev/disk/by-partlabel/${ROOT#PARTLABEL=}"
+            ;;
+        /dev/*)
+            WAIT_TARGET="$ROOT"
+            ;;
+        *)
+            WAIT_TARGET=""
+            ;;
+    esac
+fi
+
+# Precise Convergence: Block execution ONLY until the root device is fully finalized by udev.
+# Once the root path appears, the script exits immediately, leaving other non-essential devices
+# to finish processing in parallel. Includes a 3-second timeout for distribution safety.
+if [ -n "$WAIT_TARGET" ]; then
+    /bin/udevadm settle --timeout=3 --exit-if-exists="$WAIT_TARGET" || true
+else
+    # Fallback to standard full settle if the root format cannot be determined statically
+    /bin/udevadm settle --timeout=5 || true
+fi
 
 # Leave udev running to process events that come in out-of-band (like USB
 # connections)


### PR DESCRIPTION
Replace the default udevadm settle with a precise, root-device-only wait to reduce initramfs boot time.

Changes:
- Prioritize block and drm subsystems during udev trigger to accelerate critical device initialization
- Parse ROOT kernel parameter into concrete device path using shell string operations (avoid blkid/findfs which may deadlock)
- Wait only for the root device to appear via settle --exit-if-exists, leaving non-essential devices to be processed in parallel
- Add fallback full settle (5s timeout) when root format cannot be determined

This eliminates unnecessary waiting for unrelated devices, reducing the initramfs settle phase from potentially several seconds to sub-second in most cases.
性能(initramfs): 优化 udev 触发和根设备等待策略

替换默认的 udevadm settle，采用精确的、仅等待根设备的策略，
以减少 initramfs 启动时间。

改动内容：
- 在 udev trigger 时优先处理 block 和 drm 子系统，加速关键设备初始化
- 使用纯 shell 字符串操作解析 ROOT 内核参数为具体设备路径 （避免调用 blkid/findfs，防止死锁）
- 通过 settle --exit-if-exists 仅等待根设备出现，其他非关键设备 在后台并行处理
- 当无法静态确定根设备格式时，回退到完整 settle（5秒超时）

此优化消除了等待无关设备的开销，将 initramfs settle 阶段从数秒
缩短至亚秒级。