### PR TITLE
fix: hibernation err log

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+systemd (255.2-4deepin32) unstable; urgency=medium
+
+  * sleep: fix spurious "Failed to lock home directories" error when
+    systemd-homed is not running by using sd_bus_open_system() instead
+    of bus_connect_system_systemd(), ensuring the call reaches homed
+    on the standard system D-Bus rather than PID1's private bus.
+
+ -- dongshengyuan <dongshengyuan@uniontech.com>  Mon, 15 Jun 2026 10:41:55 +0800
+
 systemd (255.2-4deepin31) unstable; urgency=medium
 
   * Optimize udev trigger priority and replace full settle with

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -42,3 +42,4 @@ hwdb-reject-oob-fnmatch.patch
 exec-invoke-chdir-after-chroot.patch
 uniontech-skip-clock-restore-for-timesyncd.patch
 fix-tmpfiles-x11-cleanup.patch
+uniontech-fix-hibernation-err-log.patch

--- a/debian/patches/uniontech-fix-hibernation-err-log.patch
+++ b/debian/patches/uniontech-fix-hibernation-err-log.patch
@@ -1,0 +1,13 @@
+Index: systemd/src/sleep/sleep.c
+===================================================================
+--- systemd.orig/src/sleep/sleep.c
++++ systemd/src/sleep/sleep.c
+@@ -176,7 +176,7 @@ static int lock_all_homes(void) {
+         /* Let's synchronously lock all home directories managed by homed that have been marked for it. This
+          * way the key material required to access these volumes is hopefully removed from memory. */
+ 
+-        r = bus_connect_system_systemd(&bus);
++        r = sd_bus_open_system(&bus);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to connect to system bus: %m");
+ 


### PR DESCRIPTION
    sleep: fix spurious "Failed to lock home directories" error when
    systemd-homed is not running by using sd_bus_open_system() instead
    of bus_connect_system_systemd(), ensuring the call reaches homed
    on the standard system D-Bus rather than PID1's private bus.