### PR TITLE
fix: byte order conversion

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+systemd (255.2-4deepin33) unstable; urgency=medium
+
+  * head_data_offset is declared as le64_t in journal-def.h, so it must be assigned with htole64(p).
+
+ -- dongshengyuan <dongshengyuan@uniontech.com>  Mon, 15 Jun 2026 13:09:42 +0800
+
 systemd (255.2-4deepin32) unstable; urgency=medium
 
   * sleep: fix spurious "Failed to lock home directories" error when

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -43,3 +43,4 @@ exec-invoke-chdir-after-chroot.patch
 uniontech-skip-clock-restore-for-timesyncd.patch
 fix-tmpfiles-x11-cleanup.patch
 uniontech-fix-hibernation-err-log.patch
+uniontech-fix-byte-order-conversion.patch

--- a/debian/patches/uniontech-fix-byte-order-conversion.patch
+++ b/debian/patches/uniontech-fix-byte-order-conversion.patch
@@ -1,0 +1,13 @@
+Index: systemd/src/libsystemd/sd-journal/journal-file.c
+===================================================================
+--- systemd.orig/src/libsystemd/sd-journal/journal-file.c
++++ systemd/src/libsystemd/sd-journal/journal-file.c
+@@ -1894,7 +1894,7 @@ static int journal_file_append_data(
+ 
+         /* ... and link it in. */
+         o->data.next_field_offset = fo->field.head_data_offset;
+-        fo->field.head_data_offset = le64toh(p);
++        fo->field.head_data_offset = htole64(p);
+ 
+         if (ret_object)
+                 *ret_object = o;


### PR DESCRIPTION
head_data_offset is declared as le64_t in journal-def.h, so it must be assigned with htole64(p), not le64toh(p). All other le64_t field assignments in this file (hash, next_hash_offset) consistently use htole64().

On little-endian systems this makes no difference, but on big-endian systems the field->data link would be stored with incorrect byte order, corrupting journal file traversal.