### PR TITLE
feat: improve NUMA policy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+systemd (255.2-4deepin38) unstable; urgency=medium
+
+  * add numa policy
+  * preferred-many and weighted-interleave
+  * https://github.com/systemd/systemd/pull/42688
+
+ -- dongshengyuan <dongshengyuan@uniontech.com>  Mon, 06 Jul 2026 15:12:50 +0800
+
 systemd (255.2-4deepin37) unstable; urgency=medium
 
   * improve swap feat.

--- a/debian/patches/add-numa-policy.patch
+++ b/debian/patches/add-numa-policy.patch
@@ -1,0 +1,118 @@
+diff --git a/README b/README
+index 9f314dd..1f76e66 100644
+--- a/README
++++ b/README
+@@ -41,6 +41,8 @@ REQUIREMENTS:
+                      ≥ 5.3 for bounded loops in BPF program
+                      ≥ 5.4 for signed Verity images
+                      ≥ 5.7 for BPF links and the BPF LSM hook
++                     ≥ 5.15 for MPOL_PREFERRED_MANY NUMA policy
++                     ≥ 6.9 for MPOL_WEIGHTED_INTERLEAVE NUMA policy
+ 
+         ⛔ Kernel versions below 3.15 ("minimum baseline") are not supported at
+         all, and are missing required functionality (e.g. CLOCK_BOOTTIME
+diff --git a/src/core/exec-invoke.c b/src/core/exec-invoke.c
+index 70d963e..efafce9 100644
+--- a/src/core/exec-invoke.c
++++ b/src/core/exec-invoke.c
+@@ -4310,8 +4310,10 @@ int exec_invoke(
+ 
+         if (mpol_is_valid(numa_policy_get_type(&context->numa_policy))) {
+                 r = apply_numa_policy(&context->numa_policy);
+-                if (ERRNO_IS_NEG_NOT_SUPPORTED(r))
++                if (r == -ENOSYS)
+                         log_exec_debug_errno(context, params, r, "NUMA support not available, ignoring.");
++                else if (ERRNO_IS_NEG_NOT_SUPPORTED(r))
++                        log_exec_warning_errno(context, params, r, "NUMA policy not supported by kernel, ignoring.");
+                 else if (r < 0) {
+                         *exit_status = EXIT_NUMA_POLICY;
+                         return log_exec_error_errno(context, params, r, "Failed to set NUMA memory policy: %m");
+diff --git a/src/core/main.c b/src/core/main.c
+index 3f71cc0..07b7253 100644
+--- a/src/core/main.c
++++ b/src/core/main.c
+@@ -1714,8 +1714,10 @@ static void update_numa_policy(bool skip_setup) {
+         }
+ 
+         r = apply_numa_policy(&arg_numa_policy);
+-        if (r == -EOPNOTSUPP)
++        if (r == -ENOSYS)
+                 log_debug_errno(r, "NUMA support not available, ignoring.");
++        else if (ERRNO_IS_NEG_NOT_SUPPORTED(r))
++                log_warning_errno(r, "NUMA policy not supported by kernel, ignoring.");
+         else if (r < 0)
+                 log_warning_errno(r, "Failed to set NUMA memory policy, ignoring: %m");
+ }
+diff --git a/src/shared/numa-util.c b/src/shared/numa-util.c
+index a954ea3..5bb17bb 100644
+--- a/src/shared/numa-util.c
++++ b/src/shared/numa-util.c
+@@ -73,7 +73,7 @@ int apply_numa_policy(const NUMAPolicy *policy) {
+         assert(policy);
+ 
+         if (get_mempolicy(NULL, NULL, 0, 0, 0) < 0 && errno == ENOSYS)
+-                return -EOPNOTSUPP;
++                return -ENOSYS;
+ 
+         if (!numa_policy_is_valid(policy))
+                 return -EINVAL;
+@@ -83,8 +83,14 @@ int apply_numa_policy(const NUMAPolicy *policy) {
+                 return r;
+ 
+         r = set_mempolicy(numa_policy_get_type(policy), nodes, maxnode);
+-        if (r < 0)
++        if (r < 0) {
++                /* FIXME: This compatibility code path shall be removed once kernel 6.9
++                 *        becomes the new minimal baseline (MPOL_WEIGHTED_INTERLEAVE). */
++                if (errno == EINVAL && IN_SET(numa_policy_get_type(policy),
++                                             MPOL_PREFERRED_MANY, MPOL_WEIGHTED_INTERLEAVE))
++                        return -EOPNOTSUPP;
+                 return -errno;
++        }
+ 
+         return 0;
+ }
+@@ -178,11 +184,13 @@ int numa_mask_add_all(CPUSet *mask) {
+ }
+ 
+ static const char* const mpol_table[] = {
+-        [MPOL_DEFAULT]    = "default",
+-        [MPOL_PREFERRED]  = "preferred",
+-        [MPOL_BIND]       = "bind",
+-        [MPOL_INTERLEAVE] = "interleave",
+-        [MPOL_LOCAL]      = "local",
++        [MPOL_DEFAULT]             = "default",
++        [MPOL_PREFERRED]           = "preferred",
++        [MPOL_BIND]                = "bind",
++        [MPOL_INTERLEAVE]          = "interleave",
++        [MPOL_LOCAL]               = "local",
++        [MPOL_PREFERRED_MANY]      = "preferred-many",
++        [MPOL_WEIGHTED_INTERLEAVE] = "weighted-interleave",
+ };
+ 
+ DEFINE_STRING_TABLE_LOOKUP(mpol, int);
+diff --git a/src/shared/numa-util.h b/src/shared/numa-util.h
+index 2f736c9..9954128 100644
+--- a/src/shared/numa-util.h
++++ b/src/shared/numa-util.h
+@@ -1,11 +1,19 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ #pragma once
+ 
++/* These may be missing from older system headers */
++#ifndef MPOL_PREFERRED_MANY
++#define MPOL_PREFERRED_MANY 5
++#endif
++#ifndef MPOL_WEIGHTED_INTERLEAVE
++#define MPOL_WEIGHTED_INTERLEAVE 6
++#endif
++
+ #include "cpu-set-util.h"
+ #include "missing_syscall.h"
+ 
+ static inline bool mpol_is_valid(int t) {
+-        return t >= MPOL_DEFAULT && t <= MPOL_LOCAL;
++        return t >= MPOL_DEFAULT && t <= MPOL_WEIGHTED_INTERLEAVE;
+ }
+ 
+ typedef struct NUMAPolicy {

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -48,3 +48,4 @@ update-po-file-about-bo-and-ug.patch
 fix-double-free.patch
 fix-wrong-err-log.patch
 feat-swap-improve.patch
+add-numa-policy.patch


### PR DESCRIPTION
- Distinguish ENOSYS (no NUMA support) from EOPNOTSUPP/EINVAL (specific policy not supported by kernel)
- Update README with kernel version requirements for MPOL_PREFERRED_MANY (≥5.15) and MPOL_WEIGHTED_INTERLEAVE (≥6.9)