### PR TITLE
fix(resolved): correct malformed DNSSEC patch hunk header

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+systemd (255.2-4deepin50) unstable; urgency=medium
+
+  * Fix malformed hunk header in DNSSEC signature validation patch.
+
+ -- jiabowen <jiabowen@uniontech.com>  Fri, 31 Jul 2026 13:48:26 +0800
+
 systemd (255.2-4deepin49) unstable; urgency=medium
 
   * fix(cve): CVE-2026-40226 - nspawn: apply BindUser/Ephemeral from settings file only if trusted

--- a/debian/patches/fix-resolved-dnssec-limit-signature-validations.patch
+++ b/debian/patches/fix-resolved-dnssec-limit-signature-validations.patch
@@ -79,7 +79,7 @@ index 8788bd6b0b..33094fe0fa 100644
  }
  
  int dnssec_has_rrsig(DnsAnswer *a, const DnsResourceKey *key) {
- @@ -2564,6 +2564,7 @@ static const char* const dnssec_result_table[_DNSSEC_RESULT_MAX] = {
+@@ -2564,5 +2564,6 @@ static const char* const dnssec_result_table[_DNSSEC_RESULT_MAX] = {
          [DNSSEC_NSEC_MISMATCH]         = "nsec-mismatch",
          [DNSSEC_INCOMPATIBLE_SERVER]   = "incompatible-server",
 +        [DNSSEC_TOO_MANY_VALIDATIONS]  = "too-many-validations",


### PR DESCRIPTION
Fix the hunk header line counts so quilt parses and applies the DNSSEC signature validation patch correctly.

Bump the package version to 255.2-4deepin50.
